### PR TITLE
cli: set root argument name to 'r' for FieldResolver

### DIFF
--- a/substrate-query-framework/cli/src/generate/ModelRenderer.ts
+++ b/substrate-query-framework/cli/src/generate/ModelRenderer.ts
@@ -135,7 +135,7 @@ export class ModelRenderer extends AbstractRenderer {
         returnTypeFunc,
         rootArgType: entityName,
         fieldName: f.name,
-        rootArgName: utils.camelCase(entityName),
+        rootArgName: 'r', // disable utils.camelCase(entityName) could be a reverved ts/js keyword ie `class`
         returnType: utils.generateResolverReturnType(returnTypeFunc, f.isList),
       });
       fieldResolverImports.add(utils.generateEntityImport(returnTypeFunc));


### PR DESCRIPTION
This PR fixes `reserved word` error for FieldResolvers. 

Example, lets say you an entity named `Class` then the field resolver will look like this: 

```ts
@FieldResolver(() => Property)
async properties(@Root() class: Class): Promise<Property[]> {}
```

so the root argument name is a reserved ts/js word.