### PR TITLE
Refactor MappingProcessor to allow different event sources

### DIFF
--- a/substrate-query-framework/index-builder/package.json
+++ b/substrate-query-framework/index-builder/package.json
@@ -21,7 +21,9 @@
     "@polkadot/api": "^1.31.1",
     "@types/shortid": "^0.0.29",
     "debug": "^4.1.1",
+    "reflect-metadata": "^0.1.13",
     "shortid": "^2.2.15",
+    "typedi": "^0.8.0",
     "typeorm": "^0.2.25"
   },
   "devDependencies": {

--- a/substrate-query-framework/index-builder/src/bootstrap/Bootstrapper.ts
+++ b/substrate-query-framework/index-builder/src/bootstrap/Bootstrapper.ts
@@ -72,14 +72,14 @@ export default class Bootstrapper {
   }
 
   /**
-   * This creates a generic bootstrap event for compatibility with DB
-   * and bookeeping of successfull bootstrap events
+   * DEPRECATED, DO NOT USE
    */
   private createBootEvent(boot: BootstrapFunc): SubstrateEvent {
     return {
       event_name: 'Bootstrap',
       event_method: `Bootstrap.${boot.name}`,
       event_params: {},
+      id: 'bootstrap',
       index: (Date.now() / 1000) | 0, // simply put the timestamp here
       block_number: process.env.BLOCK_HEIGHT ? Number.parseInt(process.env.BLOCK_HEIGHT) : 0,
     };

--- a/substrate-query-framework/index-builder/src/index.ts
+++ b/substrate-query-framework/index-builder/src/index.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { BlockProducer, IndexBuilder } from './indexer';
 import BootstrapPack, { BootstrapFunc } from './bootstrap/BootstrapPack';
 
@@ -7,6 +8,7 @@ export * from './model';
 export * from './node';
 export * from './substrate';
 export * from './db';
+export * from './processor';
 
 export {
   BlockProducer,

--- a/substrate-query-framework/index-builder/src/indexer/IndexerStatusService.ts
+++ b/substrate-query-framework/index-builder/src/indexer/IndexerStatusService.ts
@@ -1,0 +1,12 @@
+import { Service } from 'typedi'
+import { getIndexerHead } from '../db/dal';
+
+@Service()
+export class IndexerStatusService {
+  
+  async getIndexerHead(): Promise<number> {
+    // TODO: replace with a Redis call or GraphQL subscription
+    return await getIndexerHead();
+  }
+
+}

--- a/substrate-query-framework/index-builder/src/indexer/index.ts
+++ b/substrate-query-framework/index-builder/src/indexer/index.ts
@@ -1,3 +1,4 @@
 export * from './BlockProducer';
 export * from './IndexBuilder';
 export * from './PooledExecutor';
+export * from './IndexerStatusService';

--- a/substrate-query-framework/index-builder/src/model/substrate-interfaces.ts
+++ b/substrate-query-framework/index-builder/src/model/substrate-interfaces.ts
@@ -18,6 +18,7 @@ export interface SubstrateEvent {
   event_method: string;
   event_params: EventParameters;
   index: number;
+  id: string;
   block_number: number;
   extrinsic?: SubstrateExtrinsic;
 }

--- a/substrate-query-framework/index-builder/src/node/QueryNodeManager.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNodeManager.ts
@@ -1,10 +1,11 @@
 import { QueryNode, QueryNodeState } from '.';
 import { Bootstrapper } from '../bootstrap';
-import MappingsProcessor from '../processor/MappingsProcessor';
+import { MappingsProcessor } from '../processor/MappingsProcessor';
 import { IndexerOptions, BootstrapOptions, ProcessorOptions } from './QueryNodeStartOptions';
 import { createDBConnection } from '../db/helper';
 import { Connection } from 'typeorm';
 import Debug from 'debug';
+import { Service } from 'typedi';
 
 
 const debug = Debug('index-builder:producer');
@@ -14,6 +15,7 @@ const debug = Debug('index-builder:producer');
 // as the integration logic between the library types and the application
 // evolves, and that will pay abstraction overhead off in terms of testability of otherwise
 // anonymous code in root file scope.
+@Service()
 export class QueryNodeManager {
   private _query_node!: QueryNode;
 
@@ -49,10 +51,11 @@ export class QueryNodeManager {
    * @param options options passed to create the mappings
    */
   async process(options: ProcessorOptions): Promise<void> {
+  
     const extraEntities = options.entities ? options.entities : [];
     await createDBConnection(extraEntities);
     
-    const processor =  MappingsProcessor.create(options);
+    const processor = new MappingsProcessor(options);
     await processor.start();
   }
 

--- a/substrate-query-framework/index-builder/src/node/QueryNodeStartOptions.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNodeStartOptions.ts
@@ -1,6 +1,5 @@
 import { QueryEventProcessingPack } from '../model';
 import { BootstrapPack } from '../bootstrap';
-
 export type QueryNodeStartUpOptions = IndexerOptions | ProcessorOptions | BootstrapOptions;
 
 export interface IndexerOptions  {

--- a/substrate-query-framework/index-builder/src/processor/DBSource.ts
+++ b/substrate-query-framework/index-builder/src/processor/DBSource.ts
@@ -1,0 +1,47 @@
+import { IProcessorSource, EventFilter } from './IProcessorSource';
+import { SubstrateEvent, EventParameters } from '../model';
+import { getRepository, MoreThan, In, LessThanOrEqual } from 'typeorm';
+import { SubstrateEventEntity } from '../entities';
+import { Inject, Service } from 'typedi';
+import { IndexerStatusService } from '../indexer';
+import { Codec } from '@polkadot/types/types';
+
+@Service('ProcessorSource')
+export class DBSource implements IProcessorSource {
+  
+
+  constructor(@Inject() protected indexerService: IndexerStatusService = new IndexerStatusService()) {}
+
+  async nextBatch(filter: EventFilter, size: number): Promise<SubstrateEvent[]> {
+    const indexerHead = await this.indexerService.getIndexerHead(); 
+    const eventEntities:SubstrateEventEntity[] = await getRepository(SubstrateEventEntity).find({ 
+      relations: ["extrinsic"],
+      where: [
+        {
+          id: MoreThan(filter.afterID),
+          name: In(filter.names),
+          blockNumber: LessThanOrEqual(indexerHead)
+        }],
+      order: {
+        id: 'ASC'
+      },
+      take: size
+    })
+    return eventEntities.map(e => this.convert(e));
+  }
+
+  private convert(qee: SubstrateEventEntity): SubstrateEvent {
+    const event_params: EventParameters = {};
+    qee.params.map((v) => { event_params[v.type] = (v.value as unknown) as Codec });
+    return {
+      event_name: qee.name,
+      event_method: qee.method,
+      event_params,
+      id: qee.id,
+      index: qee.index,
+      block_number: qee.blockNumber,
+      extrinsic: qee.extrinsic
+    } as SubstrateEvent;
+  }
+  
+}

--- a/substrate-query-framework/index-builder/src/processor/HandlerLookupService.ts
+++ b/substrate-query-framework/index-builder/src/processor/HandlerLookupService.ts
@@ -1,0 +1,41 @@
+import { Inject, Service } from 'typedi';
+import { QueryEventProcessingPack, EventHandlerFunc } from '../model';
+import { ProcessorOptions } from '../node';
+import Debug from 'debug';
+// Get the even name from the mapper name. By default, we assume the handlers
+// are of the form <section>_<method> which is translated into the canonical event name of the 
+// form <section>.<method>
+const DEFAULT_MAPPINGS_TRANSLATOR = (m: string) => `${m.split('_')[0]}.${m.split('_')[1]}`;
+
+const debug = Debug('index-builder:processor');
+
+@Service()
+export class HandlerLookupService {
+  private _events: string[] = [];
+  private _event2mapping: { [e: string]: EventHandlerFunc } = {};
+  private _processingPack: QueryEventProcessingPack;
+  private _translator = DEFAULT_MAPPINGS_TRANSLATOR;
+  
+  constructor(@Inject('ProcessorOptions') protected options: ProcessorOptions) {
+    this._processingPack = this.options.processingPack;
+    this._translator = this.options.mappingToEventTranslator || DEFAULT_MAPPINGS_TRANSLATOR;
+    this._events = Object.keys(this._processingPack).map((mapping:string) => this._translator(mapping));
+    Object.keys(this._processingPack).map((m) => {
+      this._event2mapping[this._translator(m)] = this._processingPack[m];
+    })
+
+    debug(`The following events will be processed: ${JSON.stringify(this._events, null, 2)}`);
+
+  }
+
+  eventsToHandle(): string[] {
+    return this._events;
+  }
+
+  lookupHandler(eventName: string): EventHandlerFunc {
+    return this._event2mapping[eventName]
+  }
+
+
+
+}

--- a/substrate-query-framework/index-builder/src/processor/IProcessorSource.ts
+++ b/substrate-query-framework/index-builder/src/processor/IProcessorSource.ts
@@ -1,0 +1,13 @@
+import { SubstrateEvent } from '../model';
+
+
+export interface EventFilter {
+  afterID: string
+  names: string[]
+}
+
+export interface IProcessorSource {
+  
+  nextBatch(filter: EventFilter, limit: number): Promise<SubstrateEvent[]>;
+
+}

--- a/substrate-query-framework/index-builder/src/processor/index.ts
+++ b/substrate-query-framework/index-builder/src/processor/index.ts
@@ -1,0 +1,4 @@
+export * from './DBSource'
+export * from './IProcessorSource'
+export * from './MappingsProcessor'
+export * from './HandlerLookupService'


### PR DESCRIPTION
MappingsProcessor class is broken down into multiple services; a preparatory work is set for typedi dependency injection (though it is not currently used).