### PR TITLE
Add constructor to model template

### DIFF
--- a/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -135,4 +135,11 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
   {{/is.union}}
 
 {{/fields}}
+
+{{^interfaces}}
+  constructor(init?: Partial<{{className}}>) {
+		super();
+		Object.assign(this, init);
+	}
+{{/interfaces}}
 }


### PR DESCRIPTION
This PR adds `constructor` to warthog model template. Passing objects to model constructor during initialization will be possible now:

```ts
const user = new User({ username: 'joe' })
db.save(user)
``` 