### PR TITLE
use redis pub-sub for notifying on new blocks and head updates

### DIFF
--- a/substrate-query-framework/docker-compose.yml
+++ b/substrate-query-framework/docker-compose.yml
@@ -1,6 +1,10 @@
 version: "3"
 
 services:
+  redis:
+    image: redis:6.0-alpine
+    ports:
+      - "6379:6379"
   db:
     image: postgres:12
     restart: always

--- a/substrate-query-framework/index-builder/package.json
+++ b/substrate-query-framework/index-builder/package.json
@@ -19,11 +19,15 @@
   },
   "dependencies": {
     "@polkadot/api": "^1.31.1",
+    "@types/ioredis": "^4.17.4",
     "@types/shortid": "^0.0.29",
     "debug": "^4.1.1",
     "graphql": "15",
     "graphql-request": "^3.1.0",
+    "ioredis": "^4.17.3",
     "reflect-metadata": "^0.1.13",
+    "rsmq": "^0.12.2",
+    "rsmq-promise": "^1.0.4",
     "shortid": "^2.2.15",
     "typedi": "^0.8.0",
     "typeorm": "^0.2.25"

--- a/substrate-query-framework/index-builder/src/indexer/IndexerStatusService.ts
+++ b/substrate-query-framework/index-builder/src/indexer/IndexerStatusService.ts
@@ -1,12 +1,98 @@
-import { Service } from 'typedi'
+import Container, { Service } from 'typedi'
 import { getIndexerHead } from '../db/dal';
+import Debug from 'debug';
+import * as IORedis from 'ioredis';
+import { IndexBuilder } from '..';
+import { logError } from '../utils/errors';
+import { BlockPayload, BLOCK_START_CHANNEL, BLOCK_COMPLETE_CHANNEL } from './IndexBuilder';
+import { stringifyWithTs } from '../utils/stringify';
+const debug = Debug('index-builder:indexer');
+
+export const INDEXER_NEW_HEAD_CHANNEL = 'hydra:indexer:head:new';
+export const INDEXER_HEAD_BLOCK = 'hydra:indexer:head';
+export const INDEXER_RECENTLY_COMPLETE_BLOCKS = 'hydra:indexer:block:recent';
 
 @Service()
 export class IndexerStatusService {
+
+  
+  // set containing the indexer block heights that are ahead 
+  // of the current indexer head
+  private _indexerHead = -1;
+  private initialized = false;
+  private redisSub: IORedis.Redis;
+  private redisPub: IORedis.Redis;
+  private redisClient: IORedis.Redis;
+
+  constructor() {
+    const clientFactory = Container.get<() => IORedis.Redis>('RedisClient');
+    this.redisSub = clientFactory();
+    this.redisPub = clientFactory();
+    this.redisClient = clientFactory();
+    this.redisSub.subscribe([BLOCK_START_CHANNEL, BLOCK_COMPLETE_CHANNEL])
+    .then(() =>
+      debug(`Subscribed to the indexer channels`)
+    )
+    .catch((e) => { throw new Error(e) });
+    
+    this.redisSub.on('message', (channel, message) => {
+      debug(`Got message: ${message as string}`);
+      if (channel === BLOCK_COMPLETE_CHANNEL) {
+        this.onCompleteBlock((JSON.parse(message) as BlockPayload).height)
+          .catch((e) => { throw new Error(`Error connecting to Redis: ${logError(e)}`) });
+      }
+    })
+  }  
   
   async getIndexerHead(): Promise<number> {
+    if (!this.initialized) {
+      this._indexerHead 
+      const headVal = await this.redisClient.get(INDEXER_HEAD_BLOCK);
+      debug(`Got ${headVal || 'null'} from Redis cache`);
+      if ( headVal !== null) {
+        this._indexerHead = Number.parseInt(headVal);
+      } else {
+        debug(`Redis cache is empty, loading from the database`);
+        this._indexerHead = await getIndexerHead();
+        debug(`Loaded ${this._indexerHead}`);
+        await this.updateHead();
+      }
+      this.initialized = true;
+    }
     // TODO: replace with a Redis call or GraphQL subscription
-    return await getIndexerHead();
+    return this._indexerHead;
+  }
+
+  private async updateHead(): Promise<void> {
+    await this.redisClient.set(INDEXER_HEAD_BLOCK, this._indexerHead);
+    await this.redisPub.publish(INDEXER_NEW_HEAD_CHANNEL, stringifyWithTs({height: this._indexerHead}))
+  }
+
+  /**
+   * 
+   * @param h height of the completed block
+   */
+  async onCompleteBlock(h: number): Promise<void> {
+    debug(`On complete block: ${h}`);
+    await this.redisClient.sadd(INDEXER_RECENTLY_COMPLETE_BLOCKS, `${h}`);
+    
+    let nextHead = this._indexerHead + 1;
+    let nextHeadComplete = true;
+    while (nextHeadComplete) {
+      const resp = await this.redisClient.sismember(INDEXER_RECENTLY_COMPLETE_BLOCKS, `${nextHead}`);
+      nextHeadComplete = (resp === 1); // ismember returned true;
+      if (!nextHeadComplete) {
+        break;
+      }
+      
+      await this.redisClient.set(INDEXER_HEAD_BLOCK, nextHead);
+      debug(`Updated indexer head to ${nextHead}`);
+      // remove from the set as we don't need to keep it anymore
+      await this.redisClient.srem(INDEXER_RECENTLY_COMPLETE_BLOCKS, this._indexerHead);
+      this._indexerHead = nextHead;
+      await this.updateHead();
+      nextHead++;
+    }
   }
 
 }

--- a/substrate-query-framework/index-builder/src/model/QueryEvent.ts
+++ b/substrate-query-framework/index-builder/src/model/QueryEvent.ts
@@ -21,7 +21,7 @@ export class QueryEvent {
   get event_name(): string {
     const event = this.event_record.event;
 
-    return event.section + '_' + event.method;
+    return `${event.section}.${event.method}`;
   }
 
   get event_method(): string {

--- a/substrate-query-framework/index-builder/src/node/QueryNode.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNode.ts
@@ -5,6 +5,9 @@ import { ApiPromise, WsProvider /*RuntimeVersion*/ } from '@polkadot/api';
 import { makeSubstrateService, IndexBuilder } from '..';
 import { IndexerOptions } from '.';
 import Debug from 'debug';
+import * as Redis from 'ioredis';
+
+import Container from 'typedi';
 
 const debug = Debug('index-builder:query-node');
 
@@ -69,8 +72,15 @@ export class QueryNode {
 
     const service = makeSubstrateService(api);
 
-    const index_buider = IndexBuilder.create(service);
+    const redisURL = options.redisURI || process.env.REDIS_URI;
+    if (!redisURL) {
+      throw new Error(`Redis URL is not provided`);
+    }
+    
+    Container.set('RedisClient', () => new Redis(redisURL));
 
+    const index_buider = IndexBuilder.create(service);
+    
     return new QueryNode(provider, api, index_buider, atBlock);
   }
 

--- a/substrate-query-framework/index-builder/src/node/QueryNodeStartOptions.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNodeStartOptions.ts
@@ -6,6 +6,7 @@ export interface IndexerOptions  {
   atBlock?: number;
   typeRegistrator?: () => void;
   wsProviderURI: string;
+  redisURI?: string;
 }
 
 export interface ProcessorOptions {

--- a/substrate-query-framework/index-builder/src/utils/stringify.ts
+++ b/substrate-query-framework/index-builder/src/utils/stringify.ts
@@ -1,0 +1,3 @@
+export function stringifyWithTs(s: Record<string, unknown>): string {
+  return JSON.stringify({ ...s, ts: Date.now() })
+}

--- a/substrate-query-framework/index-builder/yarn.lock
+++ b/substrate-query-framework/index-builder/yarn.lock
@@ -664,6 +664,13 @@
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.8.0.tgz#682477dbbbd07cd032731cb3b0e7eaee3d026b69"
   integrity sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==
 
+"@types/ioredis@^4.17.4":
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.17.4.tgz#e4c2d8d51ecb1f4752b660f8e19b88b1c5329b2e"
+  integrity sha512-kb5+thmQJ7HHyOAnCOeqRJlF2fyvadHghnLLLKZzCNyShStJeIQtNGGDjA30gWqj6UFSDAWBfGEMKrFDrGfvzQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/isomorphic-fetch@^0.0.35":
   version "0.0.35"
   resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz#c1c0d402daac324582b6186b91f8905340ea3361"
@@ -804,6 +811,13 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/redis@^2.8.0", "@types/redis@^2.8.18":
+  version "2.8.27"
+  resolved "https://registry.yarnpkg.com/@types/redis/-/redis-2.8.27.tgz#9bc89b472f3fc4a57a06c1823f2fc860c6c2fdf3"
+  integrity sha512-RRHarqPp3mgqHz+qzLVuQCJAIVaB3JBaczoj24QVVYu08wiCmB8vbOeNeK9lIH+pyT7+R/bbEPghAZZuhbZm0g==
+  dependencies:
+    "@types/node" "*"
 
 "@types/semver@^6.0.1":
   version "6.2.2"
@@ -1401,7 +1415,7 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
-bluebird@^3.3.5:
+bluebird@^3.3.5, bluebird@^3.5.3:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -1727,6 +1741,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -2026,6 +2045,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+denque@^1.1.0, denque@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -2074,6 +2098,11 @@ dotenv@*, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3186,6 +3215,21 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
+ioredis@^4.17.3:
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.17.3.tgz#9938c60e4ca685f75326337177bdc2e73ae9c9dc"
+  integrity sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.1.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    redis-commands "1.5.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.0.1"
+
 ip-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.1.0.tgz#5ad62f685a14edb421abebc2fff8db94df67b455"
@@ -3647,6 +3691,16 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -3737,7 +3791,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -4915,6 +4969,52 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+redis-commands@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.5.0.tgz#80d2e20698fe688f227127ff9e5164a7dd17e785"
+  integrity sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
+
+redis-commands@^1.2.0, redis-commands@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.6.0.tgz#36d4ca42ae9ed29815cdb30ad9f97982eba1ce23"
+  integrity sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+  integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
+  integrity sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==
+  dependencies:
+    double-ended-queue "^2.1.0-0"
+    redis-commands "^1.2.0"
+    redis-parser "^2.6.0"
+
+redis@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.0.2.tgz#bd47067b8a4a3e6a2e556e57f71cc82c7360150a"
+  integrity sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==
+  dependencies:
+    denque "^1.4.1"
+    redis-commands "^1.5.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -5022,6 +5122,32 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rsmq-promise@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/rsmq-promise/-/rsmq-promise-1.0.4.tgz#6fe9b1bfeb16bdb2ae7b89c802521a2d7aac43e4"
+  integrity sha512-6NJGXQf+SkfDJtdySGDuPUz7ua5R0JCKMrn/95eVwuefX3ImBXg8kiBdvXPtxM9TfnNqqIcatPTyJJVxstGWyQ==
+  dependencies:
+    bluebird "^3.5.3"
+    rsmq "^0.11.0"
+
+rsmq@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/rsmq/-/rsmq-0.11.0.tgz#c8981a5112a6176026233a863ee3f115287608ed"
+  integrity sha512-Uo+jQ85T3jbajAwoU7MGyIVRC1ytUDfMV+yjskQzIMEJDLWpcJmw+DlacM3EXwjwD9g4Q2yWdKuGXi8C2V8WIg==
+  dependencies:
+    "@types/redis" "^2.8.0"
+    lodash "^4.17.11"
+    redis "^2.8.0"
+
+rsmq@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/rsmq/-/rsmq-0.12.2.tgz#349d59eefe47682c1e28f7d91c82080ae463cf9a"
+  integrity sha512-Rr1S/YH3hQ1X4rLSkHXL9odEJldE/wtfvZxPAMRyNR3Bb5d6wiRERIAaM6CfINNd9V2H/wdoC/yNixiv+Ehvjw==
+  dependencies:
+    "@types/redis" "^2.8.18"
+    lodash "^4.17.15"
+    redis "^3.0.2"
 
 rxjs@^6.6.2, rxjs@^6.6.3:
   version "6.6.3"
@@ -5287,6 +5413,11 @@ sqlite3@^4.1.0:
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.11.0"
+
+standard-as-callback@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
+  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
 
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"


### PR DESCRIPTION
This is an initial PR for introducing a Redis-based pub-sub to the indexer. 

The following events are announced:
- A block is about to be processed
- A block has been processed
- The indexer's head has been updated

Recently completed blocks are also stored in a Redis set, which is used in order to keep the indexer head up to date.

