### PR TITLE
index-builder: warthog required fields

### DIFF
--- a/substrate-query-framework/index-builder/src/db/helper.ts
+++ b/substrate-query-framework/index-builder/src/db/helper.ts
@@ -18,16 +18,19 @@ const debug = Debug('index-builder:helper');
  * @param entity: DeepPartial<T>
  */
 export function fillRequiredWarthogFields<T>(entity: DeepPartial<T>): DeepPartial<T> {
-  // Modifying an existing entity so do not add warthog fields
-  // eslint-disable-next-line no-prototype-builtins
-  if (entity.hasOwnProperty('id')) return entity;
-
-  const requiredFields = {
-    id: shortid.generate(),
-    createdById: shortid.generate(),
-    version: 1,
-  };
-  return Object.assign(entity, requiredFields);
+  //eslint-disable-next-line no-prototype-builtins
+  if (!entity.hasOwnProperty('id')) {
+    Object.assign(entity, { id: shortid.generate() });
+  }
+  //eslint-disable-next-line no-prototype-builtins
+  if (!entity.hasOwnProperty('createdById')) {
+    Object.assign(entity, { createdById: shortid.generate() });
+  }
+  //eslint-disable-next-line no-prototype-builtins
+  if (!entity.hasOwnProperty('version')) {
+    Object.assign(entity, { version: 1 });
+  }
+  return entity;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,18 +42,17 @@ export async function createDBConnection(entities: any[] = []): Promise<Connecti
   return createConnection(_config);
 }
 
-
 export async function doInTransaction<T>(fn: (qn: QueryRunner) => Promise<T>): Promise<T> {
   const queryRunner = getConnection().createQueryRunner();
   try {
     // establish real database connection
     await queryRunner.connect();
     await queryRunner.startTransaction();
-    
+
     const result = await fn(queryRunner);
 
     await queryRunner.commitTransaction();
-    
+
     return result;
   } catch (error) {
     console.error(`Rolling back the transaction due to errors: ${logError(error)}`);

--- a/substrate-query-framework/index-builder/test/db/Helper.test.ts
+++ b/substrate-query-framework/index-builder/test/db/Helper.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import { DeepPartial } from 'typeorm';
+
+import { fillRequiredWarthogFields } from '../../src/db/helper';
+
+describe('IndexBuilder::DatabaseHelper', () => {
+  it('should fill warthog required fields', () => {
+    class Member {
+      id!: string;
+      createdById!: string;
+      version!: number;
+      constructor(init?: Partial<Member>) {
+        Object.assign(this, init);
+      }
+    }
+
+    let m: DeepPartial<Member> = new Member();
+    m = fillRequiredWarthogFields(m);
+
+    expect(m).to.haveOwnPropertyDescriptor('id', 'should have id field with value');
+    expect(m).to.haveOwnPropertyDescriptor('createdById', 'should have id field with value');
+    expect(m).to.haveOwnPropertyDescriptor('version', 'should have id field with value');
+
+    const { 0: id, 1: version } = ['asd123', 12345];
+    let m2: DeepPartial<Member> = new Member({ id, version });
+    m2 = fillRequiredWarthogFields(m2);
+
+    expect(m2.id).to.equal(id, `should have value: ${id}`);
+    expect(m2.version).to.equal(version, `should have value: ${version}`);
+  });
+});


### PR DESCRIPTION
This PR allows mappings author to pass values `id`, `version`, `createdById` field values for warthog models:

```ts
async function members_MemberRegistered(db: DB, event: SubstrateEvent) {
	const joystreamMember = decode._members_MemberRegistered(event);

	let member = new Member({ ...joystreamMember, version: event.blockNumber});
	await db.save<Member>(member);
}
```