### PR TITLE
cli: allow explicit id field in the input schema

### DIFF
--- a/substrate-query-framework/cli/src/parse/WarthogModelBuilder.ts
+++ b/substrate-query-framework/cli/src/parse/WarthogModelBuilder.ts
@@ -158,7 +158,11 @@ export class WarthogModelBuilder {
       return field;
     });
     debug(`Read and parsed fields: ${JSON.stringify(fields, null, 2)}`);
-    return fields;
+
+    // ---Temporary Solution---
+    // Warthog's BaseModel already has `id` member so we remove id field from object
+    // before generation models
+    return fields.filter(f => f.name !== 'id');
   }
 
   private generateInterfaces() {

--- a/substrate-query-framework/cli/src/parse/constant.ts
+++ b/substrate-query-framework/cli/src/parse/constant.ts
@@ -16,6 +16,7 @@ directive @${UNIQUE_DIRECTIVE} on FIELD_DEFINITION
 scalar BigInt                # Arbitrarily large integers
 scalar BigDecimal            # is used to represent arbitrary precision decimals
 scalar Bytes                 # Byte array, represented as a hexadecimal string
+scalar ID                    # Id scalar type
 type Query {
     _dummy: String           # empty queries are not allowed
 }

--- a/substrate-query-framework/cli/test/fixtures/explicit-id-field.graphql
+++ b/substrate-query-framework/cli/test/fixtures/explicit-id-field.graphql
@@ -1,0 +1,14 @@
+type Category @entity {
+  id: ID!
+  name: String!
+}
+
+type Thread @entity {
+  id: ID!
+  title: String
+}
+
+type Post @entity {
+  id: ID!
+  body: String
+}

--- a/substrate-query-framework/cli/test/helpers/ExplicitIdField.test.ts
+++ b/substrate-query-framework/cli/test/helpers/ExplicitIdField.test.ts
@@ -1,0 +1,18 @@
+import { WarthogModelBuilder } from '../../src/parse/WarthogModelBuilder';
+import { expect } from 'chai';
+
+describe('ExplicitIdFieldRemoval', () => {
+  it('should remove id field from entities', () => {
+    const generator = new WarthogModelBuilder('test/fixtures/explicit-id-field.graphql');
+    const model = generator.buildWarthogModel();
+
+    const entities = model.entities.map(e => e.name);
+    const fields: string[] = [];
+    model.entities.forEach(e => e.fields.map(f => fields.push(f.name)));
+
+    console.log(fields);
+
+    expect(fields).to.not.include('id', 'Should not detect id field');
+    expect(entities).to.include.members(['Category', 'Thread', 'Post'], 'Should detect three entities');
+  });
+});


### PR DESCRIPTION
This PR allows defining `id: ID!` field in the input schema and removes it before generating warthog model classes. We are removing the `id` field from models because warthog `codegen` command fails when there is a field named id in the model class.