### PR TITLE
Add required pagination object definitions to resolver template

### DIFF
--- a/substrate-query-framework/cli/package.json
+++ b/substrate-query-framework/cli/package.json
@@ -27,7 +27,7 @@
     "mustache": "^4.0.1",
     "tslib": "1.11.2",
     "typeorm-model-generator": "^0.4.2",
-    "warthog": "https://github.com/metmirr/warthog/releases/download/v2.9.7/warthog-v2.9.7.tgz"
+    "warthog": "https://github.com/metmirr/warthog/releases/download/v2.19/warthog-v2.19.tgz"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -1,6 +1,19 @@
-import { Arg, Args, Mutation, Query, Resolver, Root, FieldResolver} from 'type-graphql';
+import {
+  Arg,
+  Args,
+  Mutation,
+  Query,
+  Root,
+  Resolver,
+  FieldResolver,
+  ObjectType,
+  Field,
+  Int,
+  ArgsType
+} from 'type-graphql';
 import { Inject } from 'typedi';
-import { Fields, StandardDeleteResponse, UserId } from 'warthog';
+import { Min } from 'class-validator'
+import { Fields, StandardDeleteResponse, UserId, PageInfo } from 'warthog';
 
 import {
   {{className}}CreateInput,
@@ -8,7 +21,8 @@ import {
   {{className}}UpdateArgs,
   {{className}}WhereArgs,
   {{className}}WhereInput,
-  {{className}}WhereUniqueInput
+  {{className}}WhereUniqueInput,
+  {{className}}OrderByEnum,
 } from '{{{generatedFolderRelPath}}}';
 
 import { {{className}} } from './{{kebabName}}.model';
@@ -17,6 +31,57 @@ import { {{className}}Service } from './{{kebabName}}.service';
 {{#fieldResolverImports}}
   {{{.}}}
 {{/fieldResolverImports}}
+
+{{! Pagination objects -- }}
+
+@ObjectType()
+export class {{className}}Edge {
+  @Field(() => {{className}}, { nullable: false })
+  node!: {{className}};
+
+  @Field(() => String, { nullable: false })
+  cursor!: string;
+}
+
+@ObjectType()
+export class {{className}}Connection {
+  @Field(() => Int, { nullable: false })
+  totalCount!: number;
+
+  @Field(() => [{{className}}Edge], { nullable: false })
+  edges!: {{className}}Edge[];
+
+  @Field(() => PageInfo, { nullable: false })
+  pageInfo!: PageInfo;
+}
+
+@ArgsType()
+export class ConnectionPageInputOptions {
+  @Field(() => Int, { nullable: true })
+  @Min(0)
+  first?: number
+
+  @Field(() => String, { nullable: true })
+  after?: string // V3: TODO: should we make a RelayCursor scalar?
+
+  @Field(() => Int, { nullable: true })
+  @Min(0)
+  last?: number
+
+  @Field(() => String, { nullable: true })
+  before?: string
+}
+
+@ArgsType()
+export class {{className}}ConnectionWhereArgs extends ConnectionPageInputOptions {
+  @Field(() => {{className}}WhereInput, { nullable: true })
+  where?: {{className}}WhereInput;
+
+  @Field(() => {{className}}OrderByEnum, { nullable: true })
+  orderBy?: {{className}}OrderByEnum;
+}
+
+{{! -- Pagination objects }}
 
 @Resolver({{className}})
 export class {{className}}Resolver {
@@ -28,6 +93,40 @@ export class {{className}}Resolver {
     @Fields() fields: string[]
   ): Promise<{{className}}[]> {
     return this.service.find<{{className}}WhereInput>(where, orderBy, limit, offset, fields);
+  }
+
+  @Query(() => {{className}}Connection)
+  async {{camelName}}Connection(
+    @Args() { where, orderBy, ...pageOptions }: {{className}}ConnectionWhereArgs,
+    @RawFields() fields: Record<string, any>
+  ): Promise<{{className}}Connection> {
+    if (fields.edges && fields.edges?.node && fields.edges?.node?.params) {
+      fields.edges.node.params = {} // treat params as a scalar
+    }
+    let result: any = {
+      totalCount: 0,
+      edges: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false
+      }
+    };
+    // If the related database table does not have any records then an error is thrown to the client
+    // by warthog
+    try {
+      result = await this.service.findConnection<{{className}}WhereInput>(
+        where,
+        orderBy,
+        pageOptions,
+        fields
+      );
+    } catch (err) {
+      console.log(err);
+      // TODO: should continue to return this on `Error: Items is empty` or throw the error
+      if (!(err.message as string).includes('Items is empty')) throw err;
+    }
+
+    return result as Promise<{{className}}Connection>;
   }
 
   {{#fieldResolvers}}

--- a/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
+++ b/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
@@ -13,10 +13,12 @@ describe('ModelRenderer', () => {
   let warthogModel: WarthogModel;
   let modelTemplate: string;
   let enumCtxProvider: EnumContextProvider;
+  let resolverTemplate: string;
 
   before(() => {
     // set timestamp in the context to make the output predictable
     modelTemplate = fs.readFileSync('./src/templates/entities/model.ts.mst', 'utf-8');
+    resolverTemplate = fs.readFileSync('./src/templates/entities/resolver.ts.mst', 'utf-8');
   });
 
   beforeEach(() => {
@@ -329,5 +331,24 @@ describe('ModelRenderer', () => {
       expect(rendered).to.include(
         `dbValue !== undefined && dbValue !== null && dbValue.length > 0 ? new BN(dbValue, 10) : undefined`
       );
+  });
+
+  it('Should add required object definations for Pagination', () => {
+    const model = fromStringSchema(`
+    type Member @entity {
+      id: ID!
+      handle: String!
+    }
+    `);
+
+    generator = new ModelRenderer(model, model.lookupEntity('Member'), enumCtxProvider);
+    const rendered = generator.render(resolverTemplate);
+
+    expect(rendered).to.include(`MemberEdge`);
+    expect(rendered).to.include(`MemberConnection`);
+    expect(rendered).to.include(`ConnectionPageInputOptions`);
+    expect(rendered).to.include(`MemberConnectionWhereArgs`);
+    expect(rendered).to.include(`memberConnection`);
+    expect(rendered).to.include(`findConnection<MemberWhereInput>`);
   });
 });


### PR DESCRIPTION
This PR adds required pagination object definitions to the resolver template https://github.com/Joystream/joystream/issues/1350

Note: pagination feature works with this release [warthogv2.19](https://github.com/metmirr/warthog/releases/tag/v2.19)