### PR TITLE
Hydra builder 0.0.17-alpha

### DIFF
--- a/substrate-query-framework/e2e-tests/docker-compose.yml
+++ b/substrate-query-framework/e2e-tests/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - redis
     
   indexer-api-server:
-    image: indexer-api-gateway
+    image: indexer-api-gateway:latest
     restart: unless-stopped
     environment:
       - WARTHOG_STARTER_DB_DATABASE=indexer-db

--- a/substrate-query-framework/e2e-tests/run-tests.sh
+++ b/substrate-query-framework/e2e-tests/run-tests.sh
@@ -3,6 +3,9 @@ function cleanup()
     yarn post-e2e-test
 }
 
+docker build ../cli -t hydra-cli:latest --no-cache
+docker build ./schema -t hydra:latest
+docker build ../index-server -t indexer-api-server:latest
 # setup db's
 yarn pre-e2e-test
 

--- a/substrate-query-framework/e2e-tests/schema/Dockerfile
+++ b/substrate-query-framework/e2e-tests/schema/Dockerfile
@@ -1,13 +1,10 @@
 # build hydra-cli first in ../cli 
-FROM hydra-cli:0.0.14.1
+ARG HYDRA_CLI_VERSION=latest
+FROM hydra-cli:${HYDRA_CLI_VERSION}
 
 COPY schema.graphql /home/hydra
 COPY ./mappings /home/hydra/mappings
 
 RUN yarn codegen:all
-
-#use the latest version of @dzlzv/hydra-indexer-lib
-WORKDIR /home/hydra/generated/indexer
-RUN yarn upgrade @dzlzv/hydra-indexer-lib && yarn
 
 WORKDIR /home/hydra

--- a/substrate-query-framework/index-builder/CHANGELOG.md
+++ b/substrate-query-framework/index-builder/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog of major updates
 
+## 0.0.17-alpha
+
+- Bugfixes and stability improvements
+
 ## 0.0.16-alpha
 
-- Indexer supports for custom substrate types
+- Indexer supports custom substrate types
 - Substrate API stability improvements 
 
 ## 0.0.15-alpha.2

--- a/substrate-query-framework/index-builder/package.json
+++ b/substrate-query-framework/index-builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dzlzv/hydra-indexer-lib",
   "description": "Block index builder for substrate based chains",
-  "version": "0.0.16-alpha.3",
+  "version": "0.0.17-alpha",
   "main": "index.js",
   "license": "MIT",
   "repository": "git@github.com:Joystream/joystream.git",

--- a/substrate-query-framework/index-builder/src/entities/SubstrateEventEntity.ts
+++ b/substrate-query-framework/index-builder/src/entities/SubstrateEventEntity.ts
@@ -9,7 +9,6 @@ import {
 import { AnyJson, AnyJsonField } from '../interfaces/json-types'
 import { formatEventId, IQueryEvent } from '..'
 import * as BN from 'bn.js'
-import Debug from 'debug'
 import { SubstrateExtrinsicEntity } from './SubstrateExtrinsicEntity'
 import { EventParam } from '../model/substrate-interfaces'
 import { AbstractWarthogModel } from './AbstractWarthogModel'

--- a/substrate-query-framework/index-builder/src/indexer/BlockProducer.ts
+++ b/substrate-query-framework/index-builder/src/indexer/BlockProducer.ts
@@ -9,7 +9,10 @@ import { waitFor, retry, withTimeout } from '../utils/wait-for'
 import { ConstantBackOffStrategy } from '../utils/BackOffStategy'
 import { IBlockProducer } from './IBlockProducer'
 import { Service, Inject } from 'typedi'
-import { BLOCK_PRODUCER_FETCH_RETRIES, NEW_BLOCK_TIMEOUT_MS } from './indexer-consts'
+import {
+  BLOCK_PRODUCER_FETCH_RETRIES,
+  NEW_BLOCK_TIMEOUT_MS,
+} from './indexer-consts'
 
 const DEBUG_TOPIC = 'index-builder:producer'
 
@@ -75,7 +78,7 @@ export class BlockProducer implements IBlockProducer<QueryEventBlock> {
 
     // THIS IS VERY CRUDE, NEED TO MANAGE LOTS OF STUFF HERE!
     if (this._newHeadsUnsubscriber) {
-      ;(await this._newHeadsUnsubscriber)()
+      (await this._newHeadsUnsubscriber)()
     }
     debug('Block producer has been stopped')
     this._started = false

--- a/substrate-query-framework/index-builder/src/indexer/IndexerStatusService.ts
+++ b/substrate-query-framework/index-builder/src/indexer/IndexerStatusService.ts
@@ -1,145 +1,159 @@
 import Container, { Service } from 'typedi'
-import { getIndexerHead as slowIndexerHead } from '../db/dal';
-import Debug from 'debug';
-import * as IORedis from 'ioredis';
-import { logError } from '../utils/errors';
-import { BlockPayload } from './../model';
-import { stringifyWithTs } from '../utils/stringify';
-import { 
-  INDEXER_HEAD_BLOCK, 
-  INDEXER_NEW_HEAD_CHANNEL, 
-  BLOCK_START_CHANNEL, 
-  BLOCK_COMPLETE_CHANNEL, 
-  EVENT_LAST, 
-  EVENT_TOTAL, 
-  BLOCK_CACHE_PREFIX 
-} from './redis-keys';
-import { IStatusService } from './IStatusService';
-import { RedisClientFactory } from '../redis/RedisClientFactory';
-import { BLOCK_CACHE_TTL_SEC, INDEXER_HEAD_TTL_SEC } from './indexer-consts';
+import { getIndexerHead as slowIndexerHead } from '../db/dal'
+import Debug from 'debug'
+import * as IORedis from 'ioredis'
+import { logError } from '../utils/errors'
+import { BlockPayload } from './../model'
+import { stringifyWithTs } from '../utils/stringify'
+import {
+  INDEXER_HEAD_BLOCK,
+  INDEXER_NEW_HEAD_CHANNEL,
+  BLOCK_START_CHANNEL,
+  BLOCK_COMPLETE_CHANNEL,
+  EVENT_LAST,
+  EVENT_TOTAL,
+  BLOCK_CACHE_PREFIX,
+} from './redis-keys'
+import { IStatusService } from './IStatusService'
+import { RedisClientFactory } from '../redis/RedisClientFactory'
+import { BLOCK_CACHE_TTL_SEC, INDEXER_HEAD_TTL_SEC } from './indexer-consts'
 
-const debug = Debug('index-builder:status-server');
-
+const debug = Debug('index-builder:status-server')
 
 @Service('StatusService')
 export class IndexerStatusService implements IStatusService {
-
-  private redisSub: IORedis.Redis;
-  private redisPub: IORedis.Redis;
-  private redisClient: IORedis.Redis;
+  private redisSub: IORedis.Redis
+  private redisPub: IORedis.Redis
+  private redisClient: IORedis.Redis
 
   constructor() {
-    const clientFactory = Container.get<RedisClientFactory>('RedisClientFactory');
-    this.redisSub = clientFactory.getClient();
-    this.redisPub = clientFactory.getClient();
-    this.redisClient = clientFactory.getClient();
-    this.redisSub.subscribe([BLOCK_START_CHANNEL, BLOCK_COMPLETE_CHANNEL])
-    .then(() =>
-      debug(`Subscribed to the indexer channels`)
+    const clientFactory = Container.get<RedisClientFactory>(
+      'RedisClientFactory'
     )
-    .catch((e) => { throw new Error(e) });
-    
-    this.redisSub.on('message', (channel, message) => {
-      this.onNewMessage(channel, message)
-          .catch((e) => { throw new Error(`Error connecting to Redis: ${logError(e)}`) })
-    })
-  
-  }  
+    this.redisSub = clientFactory.getClient()
+    this.redisPub = clientFactory.getClient()
+    this.redisClient = clientFactory.getClient()
+    this.redisSub
+      .subscribe([BLOCK_START_CHANNEL, BLOCK_COMPLETE_CHANNEL])
+      .then(() => debug(`Subscribed to the indexer channels`))
+      .catch((e) => {
+        throw new Error(e)
+      })
 
+    this.redisSub.on('message', (channel, message) => {
+      this.onNewMessage(channel, message).catch((e) => {
+        throw new Error(`Error connecting to Redis: ${logError(e)}`)
+      })
+    })
+  }
 
   async onBlockComplete(payload: BlockPayload): Promise<void> {
     if (await this.isComplete(payload.height)) {
-      debug(`Ignoring ${payload.height}: already processed`);
-      return; 
+      debug(`Ignoring ${payload.height}: already processed`)
+      return
     }
     // TODO: move into a separate cache service and cache also events, extrinsics etc
-    await this.updateBlockCache(payload); 
-    await this.updateIndexerHead();
-    await this.updateLastEvents(payload);
-
+    await this.updateBlockCache(payload)
+    await this.updateIndexerHead()
+    await this.updateLastEvents(payload)
   }
-
 
   async onNewMessage(channel: string, message: string): Promise<void> {
     if (channel === BLOCK_COMPLETE_CHANNEL) {
-      const payload = JSON.parse(message) as BlockPayload;
-      await this.onBlockComplete(payload);
+      const payload = JSON.parse(message) as BlockPayload
+      await this.onBlockComplete(payload)
     }
   }
 
   async getIndexerHead(): Promise<number> {
-    const headVal = await this.redisClient.get(INDEXER_HEAD_BLOCK);
-    if ( headVal !== null) {
-      return Number.parseInt(headVal);
-    } 
+    const headVal = await this.redisClient.get(INDEXER_HEAD_BLOCK)
+    if (headVal !== null) {
+      return Number.parseInt(headVal)
+    }
 
-    debug(`Redis cache is empty, loading from the database`);
-    const _indexerHead = await this.slowIndexerHead();
-    debug(`Loaded ${_indexerHead}`);
-    await this.updateHeadKey(_indexerHead);
-    return _indexerHead;
+    debug(`Redis cache is empty, loading from the database`)
+    const _indexerHead = await this.slowIndexerHead()
+    debug(`Loaded ${_indexerHead}`)
+    await this.updateHeadKey(_indexerHead)
+    return _indexerHead
   }
-  
+
   /**
    * Simply re-delegate to simplify mocking purpose
-   * */ 
+   * */
   async slowIndexerHead(): Promise<number> {
-    return await slowIndexerHead();
+    return await slowIndexerHead()
   }
 
   private async updateHeadKey(height: number): Promise<void> {
     // set TTL to the indexer head key. If the indexer status is stuck for some reason,
     // this will result in fetching the indexer head from the database
-    await this.redisClient.set(INDEXER_HEAD_BLOCK, height, 'EX', INDEXER_HEAD_TTL_SEC);
-    await this.redisPub.publish(INDEXER_NEW_HEAD_CHANNEL, stringifyWithTs({ height }))
-    debug(`Updated the indexer head to ${height}`);
+    await this.redisClient.set(
+      INDEXER_HEAD_BLOCK,
+      height,
+      'EX',
+      INDEXER_HEAD_TTL_SEC
+    )
+    await this.redisPub.publish(
+      INDEXER_NEW_HEAD_CHANNEL,
+      stringifyWithTs({ height })
+    )
+    debug(`Updated the indexer head to ${height}`)
   }
 
   async updateLastEvents(payload: BlockPayload): Promise<void> {
     if (!payload.events) {
-      debug(`No events in the payload`);
-      return;
+      debug(`No events in the payload`)
+      return
     }
     for (const e of payload.events) {
-      await this.redisClient.hset(EVENT_LAST, e.name, e.id);
-      await this.redisClient.hincrby(EVENT_TOTAL, e.name, 1);
-      await this.redisClient.hincrby(EVENT_TOTAL, 'ALL', 1);
+      await this.redisClient.hset(EVENT_LAST, e.name, e.id)
+      await this.redisClient.hincrby(EVENT_TOTAL, e.name, 1)
+      await this.redisClient.hincrby(EVENT_TOTAL, 'ALL', 1)
     }
   }
 
   async updateBlockCache(payload: BlockPayload): Promise<void> {
-    await this.redisClient.set(`${BLOCK_CACHE_PREFIX}:${payload.height}`, 
-        JSON.stringify(payload), 'EX', BLOCK_CACHE_TTL_SEC)
+    await this.redisClient.set(
+      `${BLOCK_CACHE_PREFIX}:${payload.height}`,
+      JSON.stringify(payload),
+      'EX',
+      BLOCK_CACHE_TTL_SEC
+    )
   }
 
   async isComplete(h: number): Promise<boolean> {
-    const head = await this.getIndexerHead(); // this op is fast
+    const head = await this.getIndexerHead() // this op is fast
     if (h <= head) {
-       return true;
+      return true
     }
-    const isRecent = await this.redisClient.get(`${BLOCK_CACHE_PREFIX}:${h}`);
-    return (isRecent !== null); 
+    const key = `${BLOCK_CACHE_PREFIX}:${h}`
+    const isRecent = await this.redisClient.get(key)
+    const isComplete = isRecent !== null
+    if (isComplete) {
+      await this.redisClient.expire(key, BLOCK_CACHE_TTL_SEC)
+    }
+    return isComplete
   }
 
   /**
-   * 
+   *
    * @param h height of the completed block
    */
   async updateIndexerHead(): Promise<void> {
-    let head = await this.getIndexerHead();
-    let nextHeadComplete = false;
+    let head = await this.getIndexerHead()
+    let nextHeadComplete = false
     do {
-      nextHeadComplete = await this.isComplete(head + 1); 
+      nextHeadComplete = await this.isComplete(head + 1)
       if (nextHeadComplete) {
-        head++;
-      } 
+        head++
+      }
     } while (nextHeadComplete)
 
-    const currentHead = await this.getIndexerHead();
+    const currentHead = await this.getIndexerHead()
     if (head > currentHead) {
-      debug(`Updating the indexer head from ${currentHead} to ${head}`);
-      await this.updateHeadKey(head);
+      debug(`Updating the indexer head from ${currentHead} to ${head}`)
+      await this.updateHeadKey(head)
     }
   }
-
 }

--- a/substrate-query-framework/index-builder/src/node/QueryNode.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNode.ts
@@ -12,6 +12,7 @@ import typesSpec from '../substrate/typesSpec'
 import { RedisClientFactory } from '../redis/RedisClientFactory'
 import { retry, waitFor } from '../utils/wait-for'
 import { SUBSTRATE_API_CALL_RETRIES } from '../indexer/indexer-consts'
+import { RedisRelayer } from '../indexer/RedisRelayer'
 
 const debug = Debug('index-builder:query-node')
 

--- a/substrate-query-framework/index-builder/src/node/QueryNode.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNode.ts
@@ -10,7 +10,8 @@ import registry from '../substrate/typeRegistry'
 import typesSpec from '../substrate/typesSpec'
 
 import { RedisClientFactory } from '../redis/RedisClientFactory'
-import { waitFor } from '../utils/wait-for'
+import { retry, waitFor } from '../utils/wait-for'
+import { SUBSTRATE_API_CALL_RETRIES } from '../indexer/indexer-consts'
 
 const debug = Debug('index-builder:query-node')
 
@@ -74,8 +75,11 @@ export class QueryNode {
     names.length && debug(`Injected types: ${names.join(', ')}`)
 
     // Create the API and wait until ready
-    const apiPromise = new ApiPromise({ provider, registry, types, typesSpec })
-    const api = await apiPromise.isReadyOrError
+    const api = retry(
+      () =>
+        new ApiPromise({ provider, registry, types, typesSpec }).isReadyOrError,
+      SUBSTRATE_API_CALL_RETRIES
+    )
 
     debug(`Api is ready`)
 

--- a/substrate-query-framework/index-builder/src/node/QueryNode.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNode.ts
@@ -12,7 +12,6 @@ import typesSpec from '../substrate/typesSpec'
 import { RedisClientFactory } from '../redis/RedisClientFactory'
 import { retry, waitFor } from '../utils/wait-for'
 import { SUBSTRATE_API_CALL_RETRIES } from '../indexer/indexer-consts'
-import { RedisRelayer } from '../indexer/RedisRelayer'
 
 const debug = Debug('index-builder:query-node')
 

--- a/substrate-query-framework/index-builder/src/node/QueryNode.ts
+++ b/substrate-query-framework/index-builder/src/node/QueryNode.ts
@@ -76,7 +76,7 @@ export class QueryNode {
     names.length && debug(`Injected types: ${names.join(', ')}`)
 
     // Create the API and wait until ready
-    const api = retry(
+    const api = await retry(
       () =>
         new ApiPromise({ provider, registry, types, typesSpec }).isReadyOrError,
       SUBSTRATE_API_CALL_RETRIES

--- a/substrate-query-framework/index-builder/src/processor/MappingsProcessor.ts
+++ b/substrate-query-framework/index-builder/src/processor/MappingsProcessor.ts
@@ -1,7 +1,6 @@
 import { makeDatabaseManager, SubstrateEvent } from '..'
 import Debug from 'debug'
 import { doInTransaction } from '../db/helper'
-import { numberEnv } from '../utils/env-flags'
 import { ProcessorOptions } from '../node'
 import { Inject, Service } from 'typedi'
 import { IProcessorSource, GraphQLSource, HandlerLookupService } from '.'

--- a/substrate-query-framework/index-builder/src/processor/MappingsProcessor.ts
+++ b/substrate-query-framework/index-builder/src/processor/MappingsProcessor.ts
@@ -75,6 +75,10 @@ export class MappingsProcessor {
     }
 
     this._started = true
+    await waitFor(() => {
+      debug(`Waiting for the indexer head to be initialized`)
+      return this.indexerHead >= 0
+    })
     await this.processingLoop()
   }
 

--- a/substrate-query-framework/index-server/src/modules/indexer-status/indexer-status.service.ts
+++ b/substrate-query-framework/index-server/src/modules/indexer-status/indexer-status.service.ts
@@ -19,7 +19,7 @@ export class IndexerStatusService {
   async currentIndexerHead(): Promise<number> {
     const head = await this.redisClient.get(INDEXER_HEAD_BLOCK)
     if (head == null) {
-      throw new Error(`Current indexer head block is not yet published`)
+      return -1
     }
     return Number.parseInt(head as string)
   }


### PR DESCRIPTION
After https://github.com/Joystream/hydra/pull/79 and https://github.com/Joystream/hydra/pull/76
This PR adds small bugfixes and improvements:

- No error is thrown when the indexer head is not published to redis. Instead. -1 is return
- The processor waits until the indexer head becomes non-negative
- Complete blocks cache expiration is renewed after it is accessed
- Prior to running e2e-tests, all the docker images (including indexer-api-gateway) are built afresh