### PR TITLE
Add LAST_COMPLETE, MAX_COMPLETE, CHAIN_HEIGHT to Indexer status

### DIFF
--- a/substrate-query-framework/e2e-tests/docker-compose.yml
+++ b/substrate-query-framework/e2e-tests/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - GRAPHQL_SERVER_PORT=4000
     ports:
       - "4000:4000"
+    depends_on:
+      - processor
     command: ["yarn", "server:start:prod"]
 
   processor:
@@ -28,7 +30,7 @@ services:
       - TYPEORM_PORT=5432
       - INDEXER_ENDPOINT_URL=http://indexer-api-server:4000/graphql
       - PROCESSOR_POLL_INTERVAL=300 # refresh every second 
-      - DEBUG= index-builder:*
+      - DEBUG=index-builder:*
     depends_on:
       - indexer-api-server
     command: ["yarn", "processor:start"]
@@ -45,7 +47,7 @@ services:
       - NEW_BLOCK_TIMEOUT_SEC=150000
       - WS_PROVIDER_ENDPOINT_URI=ws://substrate:9944/
       - REDIS_URI=redis://redis:6379/0
-      - DEBUG=*
+      - DEBUG=index-builder:*
     command: ["yarn", "indexer:start"] 
     depends_on:
       - substrate
@@ -62,6 +64,7 @@ services:
       - WARTHOG_STARTER_DB_USERNAME=postgres 
       - WARTHOG_STARTER_REDIS_URI=redis://redis:6379/0 
       - PORT=4000
+      - DEBUG=index-server:*
     ports:
       - "4001:4000"
     depends_on:

--- a/substrate-query-framework/e2e-tests/run-tests.sh
+++ b/substrate-query-framework/e2e-tests/run-tests.sh
@@ -3,16 +3,29 @@ function cleanup()
     yarn post-e2e-test
 }
 
-docker build ../cli -t hydra-cli:latest --no-cache
+docker build ../index-builder -t index-builder:latest 
+docker build ../cli -t hydra-cli:latest 
 docker build ./schema -t hydra:latest
-docker build ../index-server -t indexer-api-server:latest
+docker build ../index-server -t indexer-api-gateway:latest
 # setup db's
 yarn pre-e2e-test
 
 sleep 10s
 
 # wait for the indexer api to start 
-timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:4001/graphql)" != "200" ]]; do sleep 5; done' || false
+attempt_counter=0
+max_attempts=50
+
+until $(curl -s --head  --request GET http://localhost:4001/graphql | grep "400" > /dev/null);  do
+    if [ ${attempt_counter} -eq ${max_attempts} ];then
+      echo "Max attempts reached"
+      break
+    fi
+
+    printf '.'
+    attempt_counter=$(($attempt_counter+1))
+    sleep 5
+done
 
 # run the actual tests
 yarn e2e-test

--- a/substrate-query-framework/e2e-tests/schema/Dockerfile
+++ b/substrate-query-framework/e2e-tests/schema/Dockerfile
@@ -7,4 +7,11 @@ COPY ./mappings /home/hydra/mappings
 
 RUN yarn codegen:all
 
+COPY --from=index-builder:latest /home/hydra-indexer-builder/index-builder.tgz /home/hydra/generated/indexer 
+
+WORKDIR /home/hydra/generated/indexer 
+RUN yarn remove @dzlzv/hydra-indexer-lib
+RUN yarn add file:index-builder.tgz
+RUN yarn install
+
 WORKDIR /home/hydra

--- a/substrate-query-framework/index-builder/Dockerfile
+++ b/substrate-query-framework/index-builder/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:12-alpine
+
+RUN mkdir -p /home/hydra-indexer-builder && chown -R node:node /home/hydra-indexer-builder
+COPY --chown=node:node . /home/hydra-indexer-builder
+
+WORKDIR /home/hydra-indexer-builder
+
+RUN yarn && yarn build
+
+RUN yarn pack --filename index-builder.tgz

--- a/substrate-query-framework/index-builder/src/indexer/IBlockProducer.ts
+++ b/substrate-query-framework/index-builder/src/indexer/IBlockProducer.ts
@@ -25,4 +25,9 @@ export interface IBlockProducer<T> {
    *  Stops producing the block
    */
   stop(): Promise<void>
+
+  /**
+   * Explicity expose 'on' method from EventEmitter to ensure listeners can listen to events
+   */
+  on(event: string | symbol, listener: (...args: any[]) => void): this
 }

--- a/substrate-query-framework/index-builder/src/indexer/RedisRelayer.ts
+++ b/substrate-query-framework/index-builder/src/indexer/RedisRelayer.ts
@@ -14,7 +14,7 @@ const debug = Debug('index-builder:redis-relayer')
  *  The main reason for it is to decouple most of the core classes from the
  *  Redis infrastructure
  **/
-@Service('RedisRelayer')
+@Service()
 export class RedisRelayer {
   private redisPub: IORedis.Redis
   private indexBuilder!: IndexBuilder

--- a/substrate-query-framework/index-builder/src/indexer/redis-keys.ts
+++ b/substrate-query-framework/index-builder/src/indexer/redis-keys.ts
@@ -1,7 +1,13 @@
-export const INDEXER_NEW_HEAD_CHANNEL = 'hydra:indexer:head:new';
-export const INDEXER_HEAD_BLOCK = 'hydra:indexer:head';
-export const BLOCK_COMPLETE_CHANNEL = 'hydra:indexer:complete:block';
-export const BLOCK_START_CHANNEL = 'hydra:indexer:started:block';
-export const EVENT_LAST = 'hydra:indexer:last:event';
-export const EVENT_TOTAL = 'hydra:indexer:total:event';
-export const BLOCK_CACHE_PREFIX = 'hydra:indexer:cache:block';
+export const INDEXER_NEW_HEAD_CHANNEL = 'hydra:indexer:head:new'
+export const INDEXER_HEAD_BLOCK = 'hydra:indexer:head'
+export const INDEXER_LAST_COMPLETE_BLOCK = 'hydra:indexer:last:complete'
+export const INDEXER_CHAIN_HEIGHT = 'hydra:indexer:chain:height'
+export const INDEXER_STATUS = 'hydra:indexer:status'
+
+export const BLOCK_COMPLETE_CHANNEL = 'hydra:indexer:complete:block'
+export const BLOCK_START_CHANNEL = 'hydra:indexer:started:block'
+export const EVENT_LAST = 'hydra:indexer:last:event'
+export const EVENT_TOTAL = 'hydra:indexer:total:event'
+export const BLOCK_CACHE_PREFIX = 'hydra:indexer:cache:block'
+
+

--- a/substrate-query-framework/index-builder/test/integration/status-service.test.ts
+++ b/substrate-query-framework/index-builder/test/integration/status-service.test.ts
@@ -14,11 +14,14 @@ import { RedisClientFactory } from '../../src/redis/RedisClientFactory'
 import { blockPayload, queryEventBlock } from '../fixtures/mock-factory'
 import { EVENT_TOTAL } from '../../src/indexer/redis-keys'
 import { clearRedis, resetDb } from './setup-db'
+import { EventEmitter } from 'events'
 
 const debug = Debug('index-builder:status-service-test')
 const FINAL_CHAIN_HEIGHT = 7
 
-class MockBlockProducer implements IBlockProducer<QueryEventBlock> {
+class MockBlockProducer
+  extends EventEmitter
+  implements IBlockProducer<QueryEventBlock> {
   private height = 0
 
   async fetchBlock(height: number): Promise<QueryEventBlock> {

--- a/substrate-query-framework/index-server/src/modules/indexer-status/indexer-status.resolver.ts
+++ b/substrate-query-framework/index-server/src/modules/indexer-status/indexer-status.resolver.ts
@@ -6,7 +6,15 @@ import { Inject } from 'typedi'
 export class IndexerStatus {
   @Field(() => Int, { nullable: false })
   head!: number
-  // TODO: more indexer metrics
+
+  @Field(() => Int, { nullable: false })
+  lastComplete!: number
+
+  @Field(() => Int, { nullable: false })
+  maxComplete!: number
+
+  @Field(() => Int, { nullable: false })
+  chainHeight!: number
 }
 
 @Resolver(IndexerStatus)
@@ -18,7 +26,6 @@ export class IndexerStatusResolver {
 
   @Query(() => IndexerStatus)
   async indexerStatus(): Promise<IndexerStatus> {
-    const head = await this.service.currentIndexerHead()
-    return { head } as IndexerStatus
+    return this.service.currentStatus()
   }
 }

--- a/substrate-query-framework/index-server/src/modules/indexer-status/indexer-status.service.ts
+++ b/substrate-query-framework/index-server/src/modules/indexer-status/indexer-status.service.ts
@@ -2,6 +2,12 @@ import { Container, Service } from 'typedi'
 import * as IORedis from 'ioredis'
 import { RedisClientFactory } from '@dzlzv/hydra-indexer-lib/lib'
 import { INDEXER_HEAD_BLOCK } from '@dzlzv/hydra-indexer-lib/lib/indexer'
+import { IndexerStatus } from './indexer-status.resolver'
+import Debug from 'debug'
+
+const debug = Debug('index-server:indexer-status-service')
+
+const INDEXER_STATUS_KEY = 'hydra:indexer:status'
 
 @Service('IndexerStatusService')
 export class IndexerStatusService {
@@ -22,5 +28,20 @@ export class IndexerStatusService {
       return -1
     }
     return Number.parseInt(head as string)
+  }
+
+  async currentStatus(): Promise<IndexerStatus> {
+    const result = await this.redisClient.hgetall(INDEXER_STATUS_KEY)
+
+    debug(`Got status: ${JSON.stringify(result)}`)
+
+    const status = new IndexerStatus()
+
+    status.head = result ? Number.parseInt(result['HEAD']) : -1
+    status.chainHeight = result ? Number.parseInt(result['CHAIN_HEIGHT']) : -1
+    status.lastComplete = result ? Number.parseInt(result['LAST_COMPLETE']) : -1
+    status.maxComplete = result ? Number.parseInt(result['MAX_COMPLETE']) : -1
+
+    return status
   }
 }


### PR DESCRIPTION
After https://github.com/Joystream/hydra/pull/80

IndexerStatusService adds the following properties to Redis:
- HEAD (Indexer Head block)
- LAST_COMPLETE (last indexed block height)
- MAX_COMPLETE (maximal height of a complete block) 
- CHAIN_HEIGHT (last block height from the chain)

The properties above are available for querying using the indexerStatus GraphQL query in indexer-api-gateway