### PR TITLE
Set nullable option true for relation decorators

### DIFF
--- a/substrate-query-framework/cli/package.json
+++ b/substrate-query-framework/cli/package.json
@@ -28,7 +28,7 @@
     "mustache": "^4.0.1",
     "tslib": "1.11.2",
     "typeorm-model-generator": "^0.4.2",
-    "warthog": "https://github.com/metmirr/warthog/releases/download/v2.20.0/warthog-v2.20.0.tgz"
+    "warthog": "https://github.com/metmirr/warthog/releases/download/v2.22.0/warthog-v2.22.0.tgz"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
+++ b/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
@@ -1,10 +1,4 @@
-import {
-  WarthogModel,
-  Field,
-  ObjectType,
-  EntityRelationship,
-  RelationType,
-} from '../model'
+import { WarthogModel, Field, ObjectType, EntityRelationship, RelationType } from '../model'
 
 import { relations } from '../helpers/relations'
 
@@ -38,14 +32,8 @@ export class RelationshipGenerator {
     this.visited.add(`${field.name}:${relatedField.name}`)
   }
 
-  listFieldWithDerivedFromDirective(
-    entity: ObjectType,
-    relatedEntity: ObjectType,
-    field: Field
-  ): boolean {
-    const relatedField = relatedEntity.fields.find(
-      (f) => field.derivedFrom && field.derivedFrom.argument === f.name
-    )
+  listFieldWithDerivedFromDirective(entity: ObjectType, relatedEntity: ObjectType, field: Field): boolean {
+    const relatedField = relatedEntity.fields.find(f => field.derivedFrom && field.derivedFrom.argument === f.name)
     if (!relatedField) {
       throw Error(
         `Incorrect relationship detected. A field like 'someField: [${entity.name}]' must exists on ${relatedEntity.name}`
@@ -54,33 +42,14 @@ export class RelationshipGenerator {
     if (this.visited.has(`${field.name}:${relatedField.name}`)) false
 
     relatedField.isList
-      ? this.createRelationship(
-          entity,
-          relatedEntity,
-          field,
-          relatedField,
-          RelationType.MTM
-        )
-      : this.createRelationship(
-          entity,
-          relatedEntity,
-          field,
-          relatedField,
-          RelationType.OTM
-        )
+      ? this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.MTM)
+      : this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.OTM)
     return true
   }
 
-  listFieldWithoutDerivedFromDirective(
-    entity: ObjectType,
-    relatedEntity: ObjectType,
-    field: Field
-  ): boolean {
+  listFieldWithoutDerivedFromDirective(entity: ObjectType, relatedEntity: ObjectType, field: Field): boolean {
     const relatedField = relatedEntity.fields.find(
-      (f) =>
-        f.type === entity.name &&
-        f.derivedFrom &&
-        f.derivedFrom.argument === field.name
+      f => f.type === entity.name && f.derivedFrom && f.derivedFrom.argument === field.name
     )
     if (relatedField === undefined) {
       throw Error(
@@ -88,27 +57,13 @@ export class RelationshipGenerator {
       )
     }
     if (this.visited.has(`${field.name}:${relatedField.name}`)) return false
-    this.createRelationship(
-      entity,
-      relatedEntity,
-      field,
-      relatedField,
-      RelationType.MTM
-    )
+    this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.MTM)
     return true
   }
 
-  fieldWithDerivedFromDirective(
-    entity: ObjectType,
-    relatedEntity: ObjectType,
-    field: Field
-  ): boolean {
+  fieldWithDerivedFromDirective(entity: ObjectType, relatedEntity: ObjectType, field: Field): boolean {
     const relatedField = relatedEntity.fields.find(
-      (f) =>
-        f.type === entity.name &&
-        f.name === field.derivedFrom?.argument &&
-        !field.isList &&
-        !f.derivedFrom
+      f => f.type === entity.name && f.name === field.derivedFrom?.argument && !field.isList && !f.derivedFrom
     )
     if (relatedField === undefined) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -118,72 +73,33 @@ export class RelationshipGenerator {
       )
     }
     if (this.visited.has(`${field.name}:${relatedField.name}`)) return false
-    this.createRelationship(
-      entity,
-      relatedEntity,
-      field,
-      relatedField,
-      RelationType.OTO
-    )
+    this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.OTO)
     return true
   }
 
-  fieldWithoutDerivedFromDirective(
-    entity: ObjectType,
-    relatedEntity: ObjectType,
-    field: Field
-  ): boolean {
+  fieldWithoutDerivedFromDirective(entity: ObjectType, relatedEntity: ObjectType, field: Field): boolean {
     // Get all the related fields
-    const relatedFields = relatedEntity.fields.filter(
-      (f) => f.type === entity.name
-    )
+    const relatedFields = relatedEntity.fields.filter(f => f.type === entity.name)
     // No fields found build OneToMany relationship
     if (relatedFields.length === 0) {
       const relatedField = relations.createAdditionalField(entity, field)
       if (this.visited.has(`${field.name}:${relatedField.name}`)) return false
-      this.createRelationship(
-        entity,
-        relatedEntity,
-        field,
-        relatedField,
-        RelationType.OTM
-      )
+      this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.OTM)
       return true
     }
 
-    const relatedField = relatedFields.find(
-      (f) =>
-        f.derivedFrom !== undefined && f.derivedFrom?.argument === field.name
-    )
+    const relatedField = relatedFields.find(f => f.derivedFrom !== undefined && f.derivedFrom?.argument === field.name)
     if (relatedField === undefined) {
       const relatedField = relations.createAdditionalField(entity, field)
       if (this.visited.has(`${field.name}:${relatedField.name}`)) return false
-      this.createRelationship(
-        entity,
-        relatedEntity,
-        field,
-        relatedField,
-        RelationType.OTM
-      )
+      this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.OTM)
       return true
     }
 
     if (this.visited.has(`${field.name}:${relatedField.name}`)) return false
     relatedField.isList
-      ? this.createRelationship(
-          entity,
-          relatedEntity,
-          field,
-          relatedField,
-          RelationType.OTM
-        )
-      : this.createRelationship(
-          entity,
-          relatedEntity,
-          field,
-          relatedField,
-          RelationType.OTO
-        )
+      ? this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.OTM)
+      : this.createRelationship(entity, relatedEntity, field, relatedField, RelationType.OTO)
     return true
   }
 
@@ -212,13 +128,13 @@ export class RelationshipGenerator {
       if (r.type !== 'otm') continue
 
       const entity = this.model.lookupEntity(r.relatedEntityName)
-      const field = entity.fields.find((f) => f.name === r.relatedField.name)
+      const field = entity.fields.find(f => f.name === r.relatedField.name)
       if (field === undefined) entity.fields.push(r.relatedField)
     }
   }
 
   buildRelationships(): void {
-    const entityNames = this.model.entities.map((t) => t.name)
+    const entityNames = this.model.entities.map(t => t.name)
 
     for (const entity of this.model.entities) {
       for (const field of entity.fields) {
@@ -230,37 +146,19 @@ export class RelationshipGenerator {
         const { isList, derivedFrom } = field
 
         if (isList && derivedFrom === undefined) {
-          if (
-            !this.listFieldWithoutDerivedFromDirective(
-              entity,
-              relatedEntity,
-              field
-            )
-          )
-            continue
+          if (!this.listFieldWithoutDerivedFromDirective(entity, relatedEntity, field)) continue
         }
 
         if (isList && derivedFrom !== undefined) {
-          if (
-            !this.listFieldWithDerivedFromDirective(
-              entity,
-              relatedEntity,
-              field
-            )
-          )
-            continue
+          if (!this.listFieldWithDerivedFromDirective(entity, relatedEntity, field)) continue
         }
 
         if (!isList && derivedFrom === undefined) {
-          if (
-            !this.fieldWithoutDerivedFromDirective(entity, relatedEntity, field)
-          )
-            continue
+          if (!this.fieldWithoutDerivedFromDirective(entity, relatedEntity, field)) continue
         }
 
         if (!isList && derivedFrom !== undefined) {
-          if (!this.fieldWithDerivedFromDirective(entity, relatedEntity, field))
-            continue
+          if (!this.fieldWithDerivedFromDirective(entity, relatedEntity, field)) continue
         }
       }
     }

--- a/substrate-query-framework/cli/src/helpers/relations.ts
+++ b/substrate-query-framework/cli/src/helpers/relations.ts
@@ -1,33 +1,30 @@
 import { EntityRelationship, Field, makeRelation, ObjectType } from '../model'
-import {
-  generateJoinColumnName,
-  generateJoinTableName,
-} from '../generate/utils'
+import { generateJoinColumnName, generateJoinTableName } from '../generate/utils'
 
 function addMany2Many(rel: EntityRelationship): void {
   const { field, relatedField, entityName, relatedEntityName } = rel
-  rel.field.relation = makeRelation('mtm', field.type, relatedField.name)
+  rel.field.relation = makeRelation('mtm', field.type, relatedField.name, field.nullable)
 
   rel.field.relation.joinTable = {
     tableName: generateJoinTableName(entityName, relatedEntityName),
     joinColumn: generateJoinColumnName(entityName),
     inverseJoinColumn: generateJoinColumnName(relatedEntityName),
   }
-  rel.relatedField.relation = makeRelation('mtm', relatedField.type, field.name)
+  rel.relatedField.relation = makeRelation('mtm', relatedField.type, field.name, relatedField.nullable)
 }
 
 function addOne2Many(rel: EntityRelationship): void {
   const { field, relatedField } = rel
 
-  rel.field.relation = makeRelation('mto', field.type, relatedField.name)
-  rel.relatedField.relation = makeRelation('otm', relatedField.type, field.name)
+  rel.field.relation = makeRelation('mto', field.type, relatedField.name, field.nullable)
+  rel.relatedField.relation = makeRelation('otm', relatedField.type, field.name, relatedField.nullable)
 }
 
 function addOne2One(rel: EntityRelationship): void {
   const { field, relatedField } = rel
 
-  rel.field.relation = makeRelation('oto', field.type, relatedField.name)
-  rel.relatedField.relation = makeRelation('oto', relatedField.type, field.name)
+  rel.field.relation = makeRelation('oto', field.type, relatedField.name, field.nullable)
+  rel.relatedField.relation = makeRelation('oto', relatedField.type, field.name, relatedField.nullable)
 
   // Decide to hold relationship on which side, joincolumn is the side that relation
   // will live
@@ -40,13 +37,7 @@ function addOne2One(rel: EntityRelationship): void {
 
 // Typeorm requires to have ManyToOne field on the related object if the relation is OneToMany
 function createAdditionalField(entity: ObjectType, field: Field): Field {
-  const f = new Field(
-    entity.name.toLowerCase() + field.name,
-    entity.name,
-    true,
-    false,
-    true
-  )
+  const f = new Field(entity.name.toLowerCase() + field.name, entity.name, true, false, true)
   f.description = 'Addtional field required to build OneToMany relationship'
   return f
 }

--- a/substrate-query-framework/cli/src/model/Relation.ts
+++ b/substrate-query-framework/cli/src/model/Relation.ts
@@ -13,6 +13,8 @@ export interface Relation {
   // Column type
   columnType: string
 
+  nullable: boolean
+
   // Table that will hold relation id (foreign key)
   joinColumn?: boolean
 
@@ -32,15 +34,12 @@ export interface FieldResolver {
   returnType: string
 }
 
-export function makeRelation(
-  type: string,
-  columnType: string,
-  relatedTsProp: string
-): Relation {
+export function makeRelation(type: string, columnType: string, relatedTsProp: string, nullable: boolean): Relation {
   return {
     type,
     columnType,
     relatedTsProp,
+    nullable,
   }
 }
 

--- a/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -62,31 +62,33 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
 
 {{#fields}}
   {{#is.otm}}
-    @OneToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    @OneToMany(
+      () => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}}
+      {{#relation.nullable}},{ nullable: true }{{/relation.nullable}}
+    )
     {{camelName}}?: {{relation.columnType}}[];  
   {{/is.otm}}
 
   {{#is.mto}}
-    @ManyToOne(() => {{relation.columnType}},
-      {{#relation.relatedTsProp}}
-        (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}},
-      {{/relation.relatedTsProp}}
-      { 
-        skipGraphQLField: true{{^required}},
-        nullable: true{{/required}} 
-    })
+    @ManyToOne(
+      () => {{relation.columnType}},
+      {{#relation.relatedTsProp}}(param: {{relation.columnType}}) => param.{{relation.relatedTsProp}},{{/relation.relatedTsProp}}
+      { skipGraphQLField: true {{#relation.nullable}},nullable: true{{/relation.nullable}} }
+    )
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}};
   {{/is.mto}}
 
   {{#is.oto}}
     {{^relation.joinColumn}}@OneToOne{{/relation.joinColumn}}
     {{#relation.joinColumn}}@OneToOneJoin{{/relation.joinColumn}}
-    (() => {{relation.columnType}},(param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    (() => {{relation.columnType}},(param: {{relation.columnType}}) => param.{{relation.relatedTsProp}} {{#relation.nullable}},{ nullable: true }{{/relation.nullable}} )
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}};
   {{/is.oto}}
 
   {{#is.mtm}}
-    @ManyToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    @ManyToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}}
+      {{#relation.nullable}},{ nullable: true }{{/relation.nullable}}
+    )
     {{#relation.joinTable}}
       @JoinTable({
         name: '{{relation.joinTable.tableName}}',

--- a/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
+++ b/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
@@ -119,13 +119,33 @@ describe('ModelRenderer', () => {
 
     expect(rendered).to.include(`import { Author } from '../author/author.model`, `Should render imports`);
     expect(rendered).to.include(
-      `@ManyToOne(() => Author, (param: Author) => param.postauthor, {
-    skipGraphQLField: true,
-  })`,
+      `@ManyToOne(() => Author, (param: Author) => param.postauthor, { skipGraphQLField: true })`,
       'Should render MTO decorator'
     ); // nullable: true is not includered?
     expect(rendered).to.include(`author!: Author;`, 'Should render required referenced field');
   });
+
+  it('should add nullable option mto decorator', function () {
+    const model = fromStringSchema(`
+    type Channel @entity {
+      handle: String!
+      language: Language
+    }
+    
+    type Language @entity {
+      code: String!
+      name: String!
+    }`)
+
+    generator = new ModelRenderer(model, model.lookupEntity('Channel'), enumCtxProvider)
+    const rendered = generator.render(modelTemplate)
+    debug(`rendered: ${JSON.stringify(rendered, null, 2)}`)
+
+    expect(rendered).to.include(
+      `@ManyToOne(() => Language, (param: Language) => param.channellanguage, { skipGraphQLField: true, nullable: true })`,
+      'Should render MTO decorator with nullable option'
+    )
+  })
 
   it('should renderer array types', function () {
     const model = fromStringSchema(`


### PR DESCRIPTION
This PR sets the`nullable` option based on the field nullable option, if the field is not required the option is set to `true`.

It depends on [warthog v2.22.0](https://github.com/metmirr/warthog/releases/tag/v2.22.0)

_Note: during the review, `substrate-query-framework/cli/src/generate/RelationshipGenerator.ts` file can be ignored. The changes come from formatting._