### PR TITLE
Add single entity query to resolver template

### DIFF
--- a/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -97,6 +97,16 @@ export class {{className}}Resolver {
     return this.service.find<{{className}}WhereInput>(where, orderBy, limit, offset, fields);
   }
 
+  @Query(() => {{className}}, { nullable: true })
+  async {{camelName}}(@Arg('where') where: {{className}}WhereUniqueInput): Promise<{{className}} | null> {
+    try {
+      return await this.service.findOne<{{className}}WhereUniqueInput>(where);
+    } catch (error) {
+      if (error.message.includes('Unable to find')) return null;
+      throw error;
+    }
+  }
+
   @Query(() => {{className}}Connection)
   async {{camelNamePlural}}Connection(
     @Args() { where, orderBy, ...pageOptions }: {{className}}ConnectionWhereArgs,

--- a/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
+++ b/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
@@ -392,4 +392,19 @@ describe('ModelRenderer', () => {
     expect(generator.render(resolverTemplate)).to.include(`videosConnection`);
     expect(generator.render(resolverTemplate)).to.include(`async videos`);
   });
+
+  it('Should add querying a single entity query', () => {
+    const model = fromStringSchema(`
+    type Channel @entity {
+      id: ID!
+      handle: String!
+    }`);
+
+    generator = new ModelRenderer(model, model.lookupEntity('Channel'), enumCtxProvider);
+    const rendered = generator.render(resolverTemplate);
+
+    expect(rendered).to.include(`Query(() => Channel, { nullable: true })`);
+    expect(rendered).to.include(`async channel(@Arg('where') where: ChannelWhereUniqueInput): Promise<Channel | null>`);
+    expect(rendered).to.include(`findOne<ChannelWhereUniqueInput>`);
+  });
 });


### PR DESCRIPTION
This PR adds a resolver to the `resolver.mst` template to query a single entity by unique where input (e.g `id`), at the moment one can fetch a list of entities.

```graphql
query {
  channel(where: { id: "1" }) {
    id
    handle
  }
}
```
