### PR TITLE
Replace warthog's findOne with typeorm's manager.findOne

### DIFF
--- a/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -98,9 +98,12 @@ export class {{className}}Resolver {
   }
 
   @Query(() => {{className}}, { nullable: true })
-  async {{camelName}}(@Arg('where') where: {{className}}WhereUniqueInput): Promise<{{className}} | null> {
-    const result = await this.service.manager.findOne({{className}}, where);
-    return result !== undefined ? result : null;
+  async {{camelName}}(
+    @Arg('where') where: {{className}}WhereUniqueInput,
+    @Fields() fields: string[]
+  ): Promise<{{className}} | null> {
+    const result = await this.service.find(where, undefined, 1, 0, fields);
+    return result && result.length >= 1 ? result[0] : null;
   }
 
   @Query(() => {{className}}Connection)

--- a/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -99,12 +99,8 @@ export class {{className}}Resolver {
 
   @Query(() => {{className}}, { nullable: true })
   async {{camelName}}(@Arg('where') where: {{className}}WhereUniqueInput): Promise<{{className}} | null> {
-    try {
-      return await this.service.findOne<{{className}}WhereUniqueInput>(where);
-    } catch (error) {
-      if (error.message.includes('Unable to find')) return null;
-      throw error;
-    }
+    const result = await this.service.manager.findOne({{className}}, where);
+    return result !== undefined ? result : null;
   }
 
   @Query(() => {{className}}Connection)

--- a/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
+++ b/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
@@ -404,7 +404,9 @@ describe('ModelRenderer', () => {
     const rendered = generator.render(resolverTemplate);
 
     expect(rendered).to.include(`Query(() => Channel, { nullable: true })`);
-    expect(rendered).to.include(`async channel(@Arg('where') where: ChannelWhereUniqueInput): Promise<Channel | null>`);
-    expect(rendered).to.include(`this.service.manager.findOne(Channel, where)`);
+    expect(rendered).to.include(
+      `async channel(@Arg('where') where: ChannelWhereUniqueInput, @Fields() fields: string[]): Promise<Channel | null>`
+    );
+    expect(rendered).to.include(`this.service.find(where, undefined, 1, 0, fields)`);
   });
 });

--- a/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
+++ b/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
@@ -405,6 +405,6 @@ describe('ModelRenderer', () => {
 
     expect(rendered).to.include(`Query(() => Channel, { nullable: true })`);
     expect(rendered).to.include(`async channel(@Arg('where') where: ChannelWhereUniqueInput): Promise<Channel | null>`);
-    expect(rendered).to.include(`findOne<ChannelWhereUniqueInput>`);
+    expect(rendered).to.include(`this.service.manager.findOne(Channel, where)`);
   });
 });


### PR DESCRIPTION
This PR replaces warthog service `findOne` method with typeorm's entity manager `findOne`. 

When querying entities on https://hydra.joystream.org/graphql I notice there is an error when if the queried entity exists for example:

```graphql
query {
  channel(where: { id: "82" }) {
    id
    handle
  }
}

### Error
{
  "errors": [
    {
      "message": "Cannot return null for non-nullable field Channel.handle.",
    ...
}
```
After debugging locally I notice that calling `this.service.findOne` generates a wrong SQL query, for the above graphql query it generates the following SQL query:
```sql
SELECT "channel"."id" AS "channel_id" FROM "channel" "channel" WHERE "channel"."id" = $1 AND "channel"."deleted_at" IS NULL LIMIT 20 -- PARAMETERS: ["1"]
```

So the query only returns the entity id all the other fields are missing.

I have found what is causing this. In the entity `<entityName>service.ts` files we override `find` method and when the `fields` parameter is undefined `find` returns only `id` field for the queried object.

