### PR TITLE
Indexer cached finilazed headers

### DIFF
--- a/substrate-query-framework/index-builder/CHANGELOG.md
+++ b/substrate-query-framework/index-builder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog of major updates
 
+## 0.0.21-
+
+- The index builder caches finalized indexer heads it subscribes to. Added `FINALIZATION_THRESHOLD` env setting to further enforce the blocks to be final
+
 ## 0.0.20-
 
 - bugfix: the indexer subscribes only for finalized heads

--- a/substrate-query-framework/index-builder/package.json
+++ b/substrate-query-framework/index-builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dzlzv/hydra-indexer-lib",
   "description": "Block index builder for substrate based chains",
-  "version": "0.0.20-legacy.1.26.1",
+  "version": "0.0.21-legacy.1.26.1",
   "main": "index.js",
   "license": "MIT",
   "repository": "git@github.com:Joystream/joystream.git",

--- a/substrate-query-framework/index-builder/package.json
+++ b/substrate-query-framework/index-builder/package.json
@@ -18,7 +18,7 @@
     "i-test": "docker-compose -f docker-compose-test.yml up -d && sh ./run-integration-tests.sh",
     "post-i-test": "docker-compose -f docker-compose-test.yml down",
     "i-test-local": "nyc --extension .ts mocha --exit --timeout 50000 --require ts-node/register --file ./test/integration/setup-db.ts \"test/integration/**/*.test.ts\"",
-    "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only \"test/**/*.test.ts\""
+    "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only --exclude \"test/integration/**/*.test.ts\"  \"test/**/*.test.ts\" \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@polkadot/api": "^1.26.1",

--- a/substrate-query-framework/index-builder/src/indexer/FIFOCache.test.ts
+++ b/substrate-query-framework/index-builder/src/indexer/FIFOCache.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai'
+import FIFOCache from './FIFOCache'
+
+describe('FIFOCache', () => {
+  it('should return first key', () => {
+    const cache = new FIFOCache<number, string>(10)
+    cache.put(1, '1')
+    cache.put(2, '2')
+
+    expect(cache.firstKey()).to.equal(1)
+  })
+
+  it('should lookup keys and values', () => {
+    const cache = new FIFOCache<number, string>(2)
+    cache.put(1, '1')
+    cache.put(2, '2')
+
+    expect(cache.getKey('1')).to.equal(1)
+    expect(cache.get(2)).to.equal('2')
+  })
+
+  it('should evict at max capacity', () => {
+    const cache = new FIFOCache<number, string>(2)
+    cache.put(1, '1')
+    cache.put(2, '2')
+    cache.put(3, '3')
+
+    expect(cache.firstKey()).to.equal(2)
+    expect(cache.size()).to.equal(2)
+    expect(cache.getKey('1')).to.be.undefined
+    expect(cache.get(1)).to.be.undefined
+
+    expect(cache.get(3)).to.equal('3')
+  })
+})

--- a/substrate-query-framework/index-builder/src/indexer/FIFOCache.ts
+++ b/substrate-query-framework/index-builder/src/indexer/FIFOCache.ts
@@ -1,0 +1,39 @@
+export default class FIFOCache<K, V> {
+  private fifoStore: Array<V> = []
+  private lookup: Map<K, V> = new Map<K, V>()
+  private inverse: Map<V, K> = new Map<V, K>()
+
+  constructor(public readonly capacity: number) {}
+
+  put(k: K, v: V): void {
+    if (this.fifoStore.length === this.capacity) {
+      const lru = this.fifoStore.shift() as V
+      const key = this.inverse.get(lru) as K
+      this.inverse.delete(lru)
+      this.lookup.delete(key)
+    }
+
+    this.fifoStore.push(v)
+    this.lookup.set(k, v)
+    this.inverse.set(v, k)
+  }
+
+  get(k: K): V | undefined {
+    return this.lookup.get(k)
+  }
+
+  firstKey(): K | undefined {
+    if (this.fifoStore.length === 0) {
+      return undefined
+    }
+    return this.inverse.get(this.fifoStore[0])
+  }
+
+  getKey(v: V): K | undefined {
+    return this.inverse.get(v)
+  }
+
+  size(): number {
+    return this.fifoStore.length
+  }
+}

--- a/substrate-query-framework/index-builder/src/indexer/indexer-consts.ts
+++ b/substrate-query-framework/index-builder/src/indexer/indexer-consts.ts
@@ -24,3 +24,10 @@ export const SUBSTRATE_API_CALL_RETRIES =
 // API is disconnected yet no error is thrown, with the block producer stuck in the waiting loop
 export const NEW_BLOCK_TIMEOUT_MS =
   numberEnv('NEW_BLOCK_TIMEOUT_MS') || 60 * 10 * 1000 // 10 minutes
+
+// number of finalized block headers retained in memory
+export const HEADER_CACHE_CAPACITY = numberEnv('HEADER_CACHE_CAPACITY') || 100
+
+// before resolving the block hash by the height, wait until it's behind the chain height
+// by at least that many blocks
+export const FINALITY_THRESHOLD = numberEnv('FINALITY_THRESHOLD') || 5


### PR DESCRIPTION
This is a more serious attempt to address the issue of non-final (and reorged) blocks being indexed by the indexer. 
- Once we get a new finaleased header from the API subscription, it is stored in an in-memory cache
- When the pipeline requests a block at a given height, the indexer 
   - if there is a cached header for the request height, get it
   - if not, wait until the required height is sufficiently behind the current chain height (the threshold is controlled by `FINALITY_THRESHOLD` env variable.