### PR TITLE
indexer caches finalized heads

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,13 @@ module.exports = {
     "sonarjs/no-identical-functions": "warn",
     "sonarjs/no-duplicate-string": "warn",
     "sonarjs/no-collapsible-if": "warn"
-  }
+  },
+  "overrides": [
+    {
+        "files": ["*.test.ts"],
+        "rules": {
+            "no-unused-expressions": "off"
+        }
+    }
+  ]
 }

--- a/packages/hydra-indexer/package.json
+++ b/packages/hydra-indexer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dzlzv/hydra-indexer",
   "description": "Block index builder for substrate based chains",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -19,13 +19,13 @@
     "i-test": "docker-compose -f docker-compose-test.yml up -d && sh ./run-integration-tests.sh",
     "post-i-test": "docker-compose -f docker-compose-test.yml down",
     "i-test-local": "nyc --extension .ts mocha --exit --timeout 50000 --require ts-node/register --file ./test/integration/setup-db.ts \"test/integration/**/*.test.ts\"",
-    "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only \"test/**/*.test.ts\" --exclude \"test/integration/**\"",
     "db:create": "createdbjs --user=${DB_USER} --password=${DB_PASS} --host=${DB_HOST} --port=${DB_PORT} ${DB_NAME}",
     "db:drop": "dropdbjs --user=${DB_USER} --password=${DB_PASS} --host=${DB_HOST} --port=${DB_PORT} ${DB_NAME}",
     "db:migrate": "node ./lib/run.js migrate",
     "db:bootstrap": "yarn db:create ; yarn db:migrate",
     "start:dev": "DEBUG=${DEBUG} ts-node src/run.ts index",
-    "start:prod": "DEBUG=${DEBUG} node ./lib/run.js index"
+    "start:prod": "DEBUG=${DEBUG} node ./lib/run.js index",
+    "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only --exclude \"test/integration/**/*.test.ts\"  \"test/**/*.test.ts\" \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@dzlzv/bn-typeorm": "^0.0.1",

--- a/packages/hydra-indexer/src/indexer/FIFOCache.test.ts
+++ b/packages/hydra-indexer/src/indexer/FIFOCache.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai'
+import FIFOCache from './FIFOCache'
+
+describe('FIFOCache', () => {
+  it('should return first key', () => {
+    const cache = new FIFOCache<number, string>(10)
+    cache.put(1, '1')
+    cache.put(2, '2')
+
+    expect(cache.firstKey()).to.equal(1)
+  })
+
+  it('should lookup keys and values', () => {
+    const cache = new FIFOCache<number, string>(2)
+    cache.put(1, '1')
+    cache.put(2, '2')
+
+    expect(cache.getKey('1')).to.equal(1)
+    expect(cache.get(2)).to.equal('2')
+  })
+
+  it('should evict at max capacity', () => {
+    const cache = new FIFOCache<number, string>(2)
+    cache.put(1, '1')
+    cache.put(2, '2')
+    cache.put(3, '3')
+
+    expect(cache.firstKey()).to.equal(2)
+    expect(cache.size()).to.equal(2)
+    expect(cache.getKey('1')).to.be.undefined
+    expect(cache.get(1)).to.be.undefined
+
+    expect(cache.get(3)).to.equal('3')
+  })
+})

--- a/packages/hydra-indexer/src/indexer/FIFOCache.ts
+++ b/packages/hydra-indexer/src/indexer/FIFOCache.ts
@@ -1,0 +1,39 @@
+export default class FIFOCache<K, V> {
+  private fifoStore: Array<V> = []
+  private lookup: Map<K, V> = new Map<K, V>()
+  private inverse: Map<V, K> = new Map<V, K>()
+
+  constructor(public readonly capacity: number) {}
+
+  put(k: K, v: V): void {
+    if (this.fifoStore.length === this.capacity) {
+      const lru = this.fifoStore.shift() as V
+      const key = this.inverse.get(lru) as K
+      this.inverse.delete(lru)
+      this.lookup.delete(key)
+    }
+
+    this.fifoStore.push(v)
+    this.lookup.set(k, v)
+    this.inverse.set(v, k)
+  }
+
+  get(k: K): V | undefined {
+    return this.lookup.get(k)
+  }
+
+  firstKey(): K | undefined {
+    if (this.fifoStore.length === 0) {
+      return undefined
+    }
+    return this.inverse.get(this.fifoStore[0])
+  }
+
+  getKey(v: V): K | undefined {
+    return this.inverse.get(v)
+  }
+
+  size(): number {
+    return this.fifoStore.length
+  }
+}

--- a/packages/hydra-indexer/src/indexer/indexer-consts.ts
+++ b/packages/hydra-indexer/src/indexer/indexer-consts.ts
@@ -24,3 +24,10 @@ export const SUBSTRATE_API_CALL_RETRIES =
 // API is disconnected yet no error is thrown, with the block producer stuck in the waiting loop
 export const NEW_BLOCK_TIMEOUT_MS =
   numberEnv('NEW_BLOCK_TIMEOUT_MS') || 60 * 10 * 1000 // 10 minutes
+
+// number of finalized block headers retained in memory
+export const HEADER_CACHE_CAPACITY = numberEnv('HEADER_CACHE_CAPACITY') || 100
+
+// before resolving the block hash by the height, wait until it's behind the chain height
+// by at least that many blocks
+export const FINALITY_THRESHOLD = numberEnv('FINALITY_THRESHOLD') || 5


### PR DESCRIPTION
Indexer watches only finalized heads. The headers of the finalized blocks are cached.