### PR TITLE
hydra-indexer: add block timestamp database migration

### DIFF
--- a/packages/hydra-indexer/src/db/ormconfig.ts
+++ b/packages/hydra-indexer/src/db/ormconfig.ts
@@ -1,11 +1,8 @@
 import { ConnectionOptions } from 'typeorm'
 import { SnakeNamingStrategy } from '@dzlzv/hydra-db-utils'
-import {
-  SubstrateEventEntity,
-  SubstrateExtrinsicEntity,
-  ProcessedEventsLogEntity,
-} from '../entities'
+import { SubstrateEventEntity, SubstrateExtrinsicEntity } from '../entities'
 import { IndexerSchema } from '../migrations/IndexerSchema'
+import { BlockTimestamp } from '../migrations/BlockTimestamp'
 
 const config: () => ConnectionOptions = () => {
   return {
@@ -19,7 +16,7 @@ const config: () => ConnectionOptions = () => {
     password: process.env.TYPEORM_PASSWORD || process.env.DB_PASS,
     database: process.env.TYPEORM_DATABASE || process.env.DB_NAME,
     entities: [SubstrateEventEntity, SubstrateExtrinsicEntity],
-    migrations: [IndexerSchema],
+    migrations: [IndexerSchema, BlockTimestamp],
     cli: {
       migrationsDir: 'migrations',
     },

--- a/packages/hydra-indexer/src/migrations/BlockTimestamp.ts
+++ b/packages/hydra-indexer/src/migrations/BlockTimestamp.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class BlockTimestamp implements MigrationInterface {
+  name = 'BlockTimestamp1607690267560'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" ADD COLUMN IF NOT EXISTS "block_timestamp" numeric NOT NULL DEFAULT 0`
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" DROP COLUMN IF EXISTS "block_timestamp"`
+    )
+  }
+}


### PR DESCRIPTION
This PR adds a migration class in order to add `block_timestamp` column to the indexer database (if there is anyone who runs indexer before we add support for `block_timestamp` then they would need to run indexer database migrations). When `BlockTimestamp` migration is run against an existing indexer database then the default value for `block_timestamp` will be set to `0`.