### PR TITLE
Add extrinsicArgs, extrinsicHash and JSON data field for the indexer Substrate event

### DIFF
--- a/packages/hydra-e2e-tests/docker-compose.yml
+++ b/packages/hydra-e2e-tests/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - REDIS_URI=redis://redis:6379/0
       - DEBUG=index-builder:*
     command: > 
-      sh -c "yarn workspace @dzlzv/hydra-indexer db:bootstrap && yarn workspace @dzlzv/hydra-indexer start:prod" 
+      sh -c "yarn db:bootstrap && yarn start:prod" 
     depends_on:
       - substrate
       - redis

--- a/packages/hydra-indexer-gateway/generated/binding.ts
+++ b/packages/hydra-indexer-gateway/generated/binding.ts
@@ -57,6 +57,8 @@ export type SubstrateEventOrderByInput =   'createdAt_ASC' |
   'extrinsicName_DESC' |
   'method_ASC' |
   'method_DESC' |
+  'extrinsicHash_ASC' |
+  'extrinsicHash_DESC' |
   'blockNumber_ASC' |
   'blockNumber_DESC' |
   'index_ASC' |
@@ -121,6 +123,9 @@ export interface SubstrateEventCreateInput {
   extrinsicName?: String | null
   method: String
   phase: JSONObject
+  data: JSONObject
+  extrinsicArgs: JSONObject
+  extrinsicHash?: String | null
   blockNumber: Float
   index: Float
   params?: JSONObject | null
@@ -133,6 +138,9 @@ export interface SubstrateEventUpdateInput {
   extrinsicName?: String | null
   method?: String | null
   phase?: JSONObject | null
+  data?: JSONObject | null
+  extrinsicArgs?: JSONObject | null
+  extrinsicHash?: String | null
   blockNumber?: Float | null
   index?: Float | null
   params?: JSONObject | null
@@ -185,6 +193,13 @@ export interface SubstrateEventWhereInput {
   method_endsWith?: String | null
   method_in?: String[] | String | null
   phase_json?: JSONObject | null
+  data_json?: JSONObject | null
+  extrinsicArgs_json?: JSONObject | null
+  extrinsicHash_eq?: String | null
+  extrinsicHash_contains?: String | null
+  extrinsicHash_startsWith?: String | null
+  extrinsicHash_endsWith?: String | null
+  extrinsicHash_in?: String[] | String | null
   blockNumber_eq?: Int | null
   blockNumber_gt?: Int | null
   blockNumber_gte?: Int | null
@@ -406,6 +421,9 @@ export interface SubstrateEvent extends BaseGraphQLObject {
   extrinsicName?: String | null
   method: String
   phase: JSONObject
+  data: JSONObject
+  extrinsicArgs: JSONObject
+  extrinsicHash?: String | null
   blockNumber: Int
   index: Int
   params?: Array<EventParam> | null

--- a/packages/hydra-indexer-gateway/generated/binding.ts
+++ b/packages/hydra-indexer-gateway/generated/binding.ts
@@ -53,12 +53,16 @@ export type SubstrateEventOrderByInput =   'createdAt_ASC' |
   'name_DESC' |
   'section_ASC' |
   'section_DESC' |
+  'extrinsicName_ASC' |
+  'extrinsicName_DESC' |
   'method_ASC' |
   'method_DESC' |
   'blockNumber_ASC' |
   'blockNumber_DESC' |
   'index_ASC' |
-  'index_DESC'
+  'index_DESC' |
+  'blockTimestamp_ASC' |
+  'blockTimestamp_DESC'
 
 export type SubstrateExtrinsicOrderByInput =   'createdAt_ASC' |
   'createdAt_DESC' |
@@ -114,21 +118,25 @@ export interface BaseWhereInput {
 export interface SubstrateEventCreateInput {
   name: String
   section?: String | null
+  extrinsicName?: String | null
   method: String
   phase: JSONObject
   blockNumber: Float
   index: Float
   params?: JSONObject | null
+  blockTimestamp: Float
 }
 
 export interface SubstrateEventUpdateInput {
   name?: String | null
   section?: String | null
+  extrinsicName?: String | null
   method?: String | null
   phase?: JSONObject | null
   blockNumber?: Float | null
   index?: Float | null
   params?: JSONObject | null
+  blockTimestamp?: Float | null
 }
 
 export interface SubstrateEventWhereInput {
@@ -166,6 +174,11 @@ export interface SubstrateEventWhereInput {
   section_startsWith?: String | null
   section_endsWith?: String | null
   section_in?: String[] | String | null
+  extrinsicName_eq?: String | null
+  extrinsicName_contains?: String | null
+  extrinsicName_startsWith?: String | null
+  extrinsicName_endsWith?: String | null
+  extrinsicName_in?: String[] | String | null
   method_eq?: String | null
   method_contains?: String | null
   method_startsWith?: String | null
@@ -185,6 +198,12 @@ export interface SubstrateEventWhereInput {
   index_lte?: Int | null
   index_in?: Int[] | Int | null
   params_json?: JSONObject | null
+  blockTimestamp_eq?: Float | null
+  blockTimestamp_gt?: Float | null
+  blockTimestamp_gte?: Float | null
+  blockTimestamp_lt?: Float | null
+  blockTimestamp_lte?: Float | null
+  blockTimestamp_in?: Float[] | Float | null
 }
 
 export interface SubstrateEventWhereUniqueInput {
@@ -384,12 +403,14 @@ export interface SubstrateEvent extends BaseGraphQLObject {
   version: Int
   name: String
   section?: String | null
+  extrinsicName?: String | null
   method: String
   phase: JSONObject
   blockNumber: Int
   index: Int
   params?: Array<EventParam> | null
   extrinsic?: SubstrateExtrinsic | null
+  blockTimestamp: BigInt
 }
 
 export interface SubstrateEventConnection {
@@ -412,7 +433,7 @@ export interface SubstrateExtrinsic extends BaseGraphQLObject {
   deletedAt?: DateTime | null
   deletedById?: String | null
   version: Int
-  tip: BigNumber
+  tip: BigInt
   blockNumber: Int
   versionInfo: String
   meta: JSONObject
@@ -430,7 +451,7 @@ export interface SubstrateExtrinsic extends BaseGraphQLObject {
 /*
 GraphQL representation of BigNumber
 */
-export type BigNumber = string
+export type BigInt = string
 
 /*
 The `Boolean` scalar type represents `true` or `false`.

--- a/packages/hydra-indexer-gateway/generated/classes.ts
+++ b/packages/hydra-indexer-gateway/generated/classes.ts
@@ -438,6 +438,9 @@ export enum SubstrateEventOrderByEnum {
   method_ASC = "method_ASC",
   method_DESC = "method_DESC",
 
+  extrinsicHash_ASC = "extrinsicHash_ASC",
+  extrinsicHash_DESC = "extrinsicHash_DESC",
+
   blockNumber_ASC = "blockNumber_ASC",
   blockNumber_DESC = "blockNumber_DESC",
 
@@ -589,6 +592,27 @@ export class SubstrateEventWhereInput {
   @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
   phase_json?: JsonObject;
 
+  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
+  data_json?: JsonObject;
+
+  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
+  extrinsicArgs_json?: JsonObject;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicHash_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicHash_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicHash_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicHash_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  extrinsicHash_in?: string[];
+
   @TypeGraphQLField(() => Int, { nullable: true })
   blockNumber_eq?: number;
 
@@ -670,6 +694,15 @@ export class SubstrateEventCreateInput {
   @TypeGraphQLField(() => GraphQLJSONObject)
   phase!: JsonObject;
 
+  @TypeGraphQLField(() => GraphQLJSONObject)
+  data!: JsonObject;
+
+  @TypeGraphQLField(() => GraphQLJSONObject)
+  extrinsicArgs!: JsonObject;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicHash?: string;
+
   @TypeGraphQLField()
   blockNumber!: number;
 
@@ -699,6 +732,15 @@ export class SubstrateEventUpdateInput {
 
   @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
   phase?: JsonObject;
+
+  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
+  data?: JsonObject;
+
+  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
+  extrinsicArgs?: JsonObject;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicHash?: string;
 
   @TypeGraphQLField({ nullable: true })
   blockNumber?: number;

--- a/packages/hydra-indexer-gateway/generated/classes.ts
+++ b/packages/hydra-indexer-gateway/generated/classes.ts
@@ -432,6 +432,9 @@ export enum SubstrateEventOrderByEnum {
   section_ASC = "section_ASC",
   section_DESC = "section_DESC",
 
+  extrinsicName_ASC = "extrinsicName_ASC",
+  extrinsicName_DESC = "extrinsicName_DESC",
+
   method_ASC = "method_ASC",
   method_DESC = "method_DESC",
 
@@ -439,7 +442,10 @@ export enum SubstrateEventOrderByEnum {
   blockNumber_DESC = "blockNumber_DESC",
 
   index_ASC = "index_ASC",
-  index_DESC = "index_DESC"
+  index_DESC = "index_DESC",
+
+  blockTimestamp_ASC = "blockTimestamp_ASC",
+  blockTimestamp_DESC = "blockTimestamp_DESC"
 }
 
 registerEnumType(SubstrateEventOrderByEnum, {
@@ -551,6 +557,21 @@ export class SubstrateEventWhereInput {
   section_in?: string[];
 
   @TypeGraphQLField({ nullable: true })
+  extrinsicName_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicName_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicName_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicName_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  extrinsicName_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
   method_eq?: string;
 
   @TypeGraphQLField({ nullable: true })
@@ -606,6 +627,24 @@ export class SubstrateEventWhereInput {
 
   @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
   params_json?: JsonObject;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  blockTimestamp_eq?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  blockTimestamp_gt?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  blockTimestamp_gte?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  blockTimestamp_lt?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  blockTimestamp_lte?: number;
+
+  @TypeGraphQLField(() => [Float], { nullable: true })
+  blockTimestamp_in?: number[];
 }
 
 @TypeGraphQLInputType()
@@ -622,6 +661,9 @@ export class SubstrateEventCreateInput {
   @TypeGraphQLField({ nullable: true })
   section?: string;
 
+  @TypeGraphQLField({ nullable: true })
+  extrinsicName?: string;
+
   @TypeGraphQLField()
   method!: string;
 
@@ -636,6 +678,9 @@ export class SubstrateEventCreateInput {
 
   @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
   params?: JsonObject;
+
+  @TypeGraphQLField()
+  blockTimestamp!: number;
 }
 
 @TypeGraphQLInputType()
@@ -645,6 +690,9 @@ export class SubstrateEventUpdateInput {
 
   @TypeGraphQLField({ nullable: true })
   section?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  extrinsicName?: string;
 
   @TypeGraphQLField({ nullable: true })
   method?: string;
@@ -660,6 +708,9 @@ export class SubstrateEventUpdateInput {
 
   @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
   params?: JsonObject;
+
+  @TypeGraphQLField({ nullable: true })
+  blockTimestamp?: number;
 }
 
 @ArgsType()

--- a/packages/hydra-indexer-gateway/generated/schema.graphql
+++ b/packages/hydra-indexer-gateway/generated/schema.graphql
@@ -56,7 +56,7 @@ input BaseWhereInput {
 }
 
 """GraphQL representation of BigNumber"""
-scalar BigNumber
+scalar BigInt
 
 """
 The javascript `Date` as string. Type represents date and time as the ISO Date string.
@@ -127,12 +127,14 @@ type SubstrateEvent implements BaseGraphQLObject {
   version: Int!
   name: String!
   section: String
+  extrinsicName: String
   method: String!
   phase: JSONObject!
   blockNumber: Int!
   index: Int!
   params: [EventParam!]
   extrinsic: SubstrateExtrinsic
+  blockTimestamp: BigInt!
 }
 
 type SubstrateEventConnection {
@@ -144,11 +146,13 @@ type SubstrateEventConnection {
 input SubstrateEventCreateInput {
   name: String!
   section: String
+  extrinsicName: String
   method: String!
   phase: JSONObject!
   blockNumber: Float!
   index: Float!
   params: JSONObject
+  blockTimestamp: Float!
 }
 
 type SubstrateEventEdge {
@@ -167,22 +171,28 @@ enum SubstrateEventOrderByInput {
   name_DESC
   section_ASC
   section_DESC
+  extrinsicName_ASC
+  extrinsicName_DESC
   method_ASC
   method_DESC
   blockNumber_ASC
   blockNumber_DESC
   index_ASC
   index_DESC
+  blockTimestamp_ASC
+  blockTimestamp_DESC
 }
 
 input SubstrateEventUpdateInput {
   name: String
   section: String
+  extrinsicName: String
   method: String
   phase: JSONObject
   blockNumber: Float
   index: Float
   params: JSONObject
+  blockTimestamp: Float
 }
 
 input SubstrateEventWhereInput {
@@ -220,6 +230,11 @@ input SubstrateEventWhereInput {
   section_startsWith: String
   section_endsWith: String
   section_in: [String!]
+  extrinsicName_eq: String
+  extrinsicName_contains: String
+  extrinsicName_startsWith: String
+  extrinsicName_endsWith: String
+  extrinsicName_in: [String!]
   method_eq: String
   method_contains: String
   method_startsWith: String
@@ -239,6 +254,12 @@ input SubstrateEventWhereInput {
   index_lte: Int
   index_in: [Int!]
   params_json: JSONObject
+  blockTimestamp_eq: Float
+  blockTimestamp_gt: Float
+  blockTimestamp_gte: Float
+  blockTimestamp_lt: Float
+  blockTimestamp_lte: Float
+  blockTimestamp_in: [Float!]
 }
 
 input SubstrateEventWhereUniqueInput {
@@ -254,7 +275,7 @@ type SubstrateExtrinsic implements BaseGraphQLObject {
   deletedAt: DateTime
   deletedById: String
   version: Int!
-  tip: BigNumber!
+  tip: BigInt!
   blockNumber: Int!
   versionInfo: String!
   meta: JSONObject!

--- a/packages/hydra-indexer-gateway/generated/schema.graphql
+++ b/packages/hydra-indexer-gateway/generated/schema.graphql
@@ -130,6 +130,9 @@ type SubstrateEvent implements BaseGraphQLObject {
   extrinsicName: String
   method: String!
   phase: JSONObject!
+  data: JSONObject!
+  extrinsicArgs: JSONObject!
+  extrinsicHash: String
   blockNumber: Int!
   index: Int!
   params: [EventParam!]
@@ -149,6 +152,9 @@ input SubstrateEventCreateInput {
   extrinsicName: String
   method: String!
   phase: JSONObject!
+  data: JSONObject!
+  extrinsicArgs: JSONObject!
+  extrinsicHash: String
   blockNumber: Float!
   index: Float!
   params: JSONObject
@@ -175,6 +181,8 @@ enum SubstrateEventOrderByInput {
   extrinsicName_DESC
   method_ASC
   method_DESC
+  extrinsicHash_ASC
+  extrinsicHash_DESC
   blockNumber_ASC
   blockNumber_DESC
   index_ASC
@@ -189,6 +197,9 @@ input SubstrateEventUpdateInput {
   extrinsicName: String
   method: String
   phase: JSONObject
+  data: JSONObject
+  extrinsicArgs: JSONObject
+  extrinsicHash: String
   blockNumber: Float
   index: Float
   params: JSONObject
@@ -241,6 +252,13 @@ input SubstrateEventWhereInput {
   method_endsWith: String
   method_in: [String!]
   phase_json: JSONObject
+  data_json: JSONObject
+  extrinsicArgs_json: JSONObject
+  extrinsicHash_eq: String
+  extrinsicHash_contains: String
+  extrinsicHash_startsWith: String
+  extrinsicHash_endsWith: String
+  extrinsicHash_in: [String!]
   blockNumber_eq: Int
   blockNumber_gt: Int
   blockNumber_gte: Int

--- a/packages/hydra-indexer-gateway/package.json
+++ b/packages/hydra-indexer-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dzlzv/hydra-indexer-gateway",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Generated Warthog Project",
   "license": "MIT",
   "scripts": {

--- a/packages/hydra-indexer-gateway/package.json
+++ b/packages/hydra-indexer-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dzlzv/hydra-indexer-gateway",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Generated Warthog Project",
   "license": "MIT",
   "scripts": {

--- a/packages/hydra-indexer-gateway/src/modules/substrate-event/substrate-event.model.ts
+++ b/packages/hydra-indexer-gateway/src/modules/substrate-event/substrate-event.model.ts
@@ -40,6 +40,11 @@ export class SubstrateEvent extends BaseModel {
   })
   section?: string
 
+  @StringField({
+    nullable: true,
+  })
+  extrinsicName?: string
+
   @StringField()
   method!: string
 

--- a/packages/hydra-indexer-gateway/src/modules/substrate-event/substrate-event.model.ts
+++ b/packages/hydra-indexer-gateway/src/modules/substrate-event/substrate-event.model.ts
@@ -51,6 +51,15 @@ export class SubstrateEvent extends BaseModel {
   @JSONField()
   phase!: AnyJson
 
+  @JSONField()
+  data!: AnyJson
+
+  @JSONField()
+  extrinsicArgs!: AnyJson
+
+  @StringField({ nullable: true })
+  extrinsicHash?: string
+
   @IntField()
   blockNumber!: number
 

--- a/packages/hydra-indexer/CHANGELOG.md
+++ b/packages/hydra-indexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog of major updates
 
+## 0.1.5  
+
+- Added `extrinsicName` field to events
+
 ## 0.1.4
 
 - Added blocktimestamp

--- a/packages/hydra-indexer/CHANGELOG.md
+++ b/packages/hydra-indexer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog of major updates
 
+## 0.1.6
+
+Added fields to SubstrateEvent entity:
+    - `data`: JSONified event parameters
+    - `extrinsicArgs`: JSONified extrinsic arguments
+    - `extrinsicHash`: Extrinsic hash (if present)
+
 ## 0.1.5  
 
 - Added `extrinsicName` field to events

--- a/packages/hydra-indexer/Dockerfile
+++ b/packages/hydra-indexer/Dockerfile
@@ -24,4 +24,6 @@ RUN yarn workspace @dzlzv/hydra-common build
 RUN yarn workspace @dzlzv/hydra-db-utils build
 RUN yarn workspace @dzlzv/hydra-indexer build 
 
-CMD yarn workspace @dzlzv/hydra-indexer start:prod
+WORKDIR /home/hydra/packages/hydra-indexer
+
+CMD yarn start:prod

--- a/packages/hydra-indexer/package.json
+++ b/packages/hydra-indexer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dzlzv/hydra-indexer",
   "description": "Block index builder for substrate based chains",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/packages/hydra-indexer/package.json
+++ b/packages/hydra-indexer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dzlzv/hydra-indexer",
   "description": "Block index builder for substrate based chains",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "pub": "yarn build && yarn publish --access public",
-    "docker:build": "docker build -t joystream/hydra-indexer:latest .",
+    "docker:build": "docker build ./../../ -f ../hydra-indexer/Dockerfile -t joystream/hydra-indexer:latest ",
     "docker:tag-latest": "docker tag joystream/hydra-indexer:latest joystream/hydra-indexer:${TAG}",
     "docker:publish": "export TAG=$(node -p 'require(\"./package.json\").version') && yarn docker:build && yarn docker:tag-latest && docker push joystream/hydra-indexer",
     "build": "rm -rf lib && tsc --build tsconfig.json",

--- a/packages/hydra-indexer/src/db/ormconfig.ts
+++ b/packages/hydra-indexer/src/db/ormconfig.ts
@@ -1,8 +1,6 @@
 import { ConnectionOptions } from 'typeorm'
 import { SnakeNamingStrategy } from '@dzlzv/hydra-db-utils'
 import { SubstrateEventEntity, SubstrateExtrinsicEntity } from '../entities'
-import { IndexerSchema } from '../migrations/IndexerSchema'
-import { BlockTimestamp } from '../migrations/BlockTimestamp'
 
 const config: () => ConnectionOptions = () => {
   return {
@@ -16,7 +14,7 @@ const config: () => ConnectionOptions = () => {
     password: process.env.TYPEORM_PASSWORD || process.env.DB_PASS,
     database: process.env.TYPEORM_DATABASE || process.env.DB_NAME,
     entities: [SubstrateEventEntity, SubstrateExtrinsicEntity],
-    migrations: [IndexerSchema, BlockTimestamp],
+    migrations: ['./**/migrations/*.js'],
     cli: {
       migrationsDir: 'migrations',
     },

--- a/packages/hydra-indexer/src/entities/SubstrateEventEntity.ts
+++ b/packages/hydra-indexer/src/entities/SubstrateEventEntity.ts
@@ -32,6 +32,9 @@ export class SubstrateEventEntity extends AbstractWarthogModel {
   })
   section?: string
 
+  @Column({ nullable: true })
+  extrinsicName?: string
+
   @Column()
   method!: string
 
@@ -104,8 +107,11 @@ export class SubstrateEventEntity extends AbstractWarthogModel {
       extr.blockNumber = q.blockNumber
       extr.signature = e.signature.toString()
       extr.signer = e.signer.toString()
+
       extr.method = e.method.methodName || 'NO_METHOD'
       extr.section = e.method.sectionName || 'NO_SECTION'
+      _entity.extrinsicName = `${extr.method}.${extr.section}`
+
       extr.meta = (e.meta.toJSON() || {}) as AnyJson
       extr.hash = e.hash.toString()
       extr.isSigned = e.isSigned

--- a/packages/hydra-indexer/src/migrations/BlockTimestamp1607690267560.ts
+++ b/packages/hydra-indexer/src/migrations/BlockTimestamp1607690267560.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class BlockTimestamp implements MigrationInterface {
+export class BlockTimestamp1607690267560 implements MigrationInterface {
   name = 'BlockTimestamp1607690267560'
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/packages/hydra-indexer/src/migrations/EventExtraFields1612537639000.ts
+++ b/packages/hydra-indexer/src/migrations/EventExtraFields1612537639000.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class EventExtraFields1612537639000 implements MigrationInterface {
+  name = 'EventExtraFields1612537639000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" ADD COLUMN IF NOT EXISTS "extrinsic_args" jsonb  NOT NULL DEFAULT '{}'::jsonb`
+    )
+    await queryRunner.query(
+      `CREATE INDEX "substrate_event_args_idx" ON "substrate_event" USING gin("extrinsic_args")`
+    )
+
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" ADD COLUMN IF NOT EXISTS "extrinsic_hash" character varying`
+    )
+    await queryRunner.query(
+      `CREATE INDEX "extrinsic_hash_idx" ON "substrate_event" ("extrinsic_hash") `
+    )
+
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" ADD COLUMN IF NOT EXISTS "data" jsonb NOT NULL DEFAULT '{}'::jsonb`
+    )
+    await queryRunner.query(
+      `CREATE INDEX "substrate_event_data_idx" ON "substrate_event" USING gin("data")`
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" DROP COLUMN IF EXISTS "extrinsic_args"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" DROP COLUMN IF EXISTS "extrinsic_hash"`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" DROP COLUMN IF EXISTS "data"`
+    )
+    await queryRunner.query(`DROP INDEX "extrinsic_hash_idx" `)
+    await queryRunner.query(`DROP INDEX "substrate_event_args_idx" `)
+    await queryRunner.query(`DROP INDEX "substrate_event_data_idx" `)
+  }
+}

--- a/packages/hydra-indexer/src/migrations/ExtrinsicName1612537537000.ts
+++ b/packages/hydra-indexer/src/migrations/ExtrinsicName1612537537000.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ExtrinsicName1612537537000 implements MigrationInterface {
+  name = 'ExtrinsicName1612537537000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" ADD COLUMN IF NOT EXISTS "extrinsic_name" character varying`
+    )
+    await queryRunner.query(
+      `CREATE INDEX "extrinsic_name_idx" ON "substrate_event" ("extrinsic_name") `
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "substrate_event" DROP COLUMN IF EXISTS "extrinsic_name"`
+    )
+    await queryRunner.query(`DROP INDEX "extrinsic_name_idx" `)
+  }
+}

--- a/packages/hydra-indexer/src/migrations/IndexerSchema1601637366082.ts
+++ b/packages/hydra-indexer/src/migrations/IndexerSchema1601637366082.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class IndexerSchema implements MigrationInterface {
+export class IndexerSchema1601637366082 implements MigrationInterface {
   name = 'IndexerSchema1601637366082'
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/packages/hydra-indexer/src/run.ts
+++ b/packages/hydra-indexer/src/run.ts
@@ -79,13 +79,14 @@ async function runIndexer(opts: Record<string, unknown>) {
   const node = new QueryNodeManager()
   const atBlock = process.env.BLOCK_HEIGHT
 
-  const typesPath = path.join(
-    process.cwd(),
-    (process.env.TYPES_JSON || opts.typedefs || '') as string
-  )
+  const typesPath = process.env.TYPES_JSON || opts.typedefs
+
   const types = typesPath
     ? // eslint-disable-next-line @typescript-eslint/no-var-requires
-      (require(typesPath) as Record<string, Record<string, string>>)
+      (require(path.resolve(typesPath as string)) as Record<
+        string,
+        Record<string, string>
+      >)
     : {}
 
   const wsProviderURI = (process.env.WS_PROVIDER_ENDPOINT_URI ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,20 +332,6 @@
   dependencies:
     bn.js "^5.1.3"
 
-"@dzlzv/hydra-processor@0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-processor/-/hydra-processor-0.0.7.tgz#54159045cce50d98dbd71d67b0dbc6036b537da9"
-  integrity sha512-PoZ3a6tv9KL26UEuKS/0MHOFNFu9EYa2D0q9ugzopFoT+CBTAy1uyp20PSqwhHIkWgEbqsrsvJyOoRyNIqmyag==
-  dependencies:
-    "@dzlzv/hydra-common" "^0.0.3"
-    "@dzlzv/hydra-db-utils" "^0.0.2"
-    bn.js "^5.1.3"
-    express "^4.17.1"
-    graphql "^15.4.0"
-    graphql-request "^3.3.0"
-    prom-client "^12.0.0"
-    typedi "^0.8.0"
-
 "@edgeware/node-types@~3.0.10":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@edgeware/node-types/-/node-types-3.0.11.tgz#a2ff3fbacd2ee600fb125ad9a4bbef4300a273c7"
@@ -3668,11 +3654,6 @@ commander@^4.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
 commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
@@ -4972,7 +4953,7 @@ fetch@^1.1.0:
     biskviit "1.0.1"
     encoding "0.1.12"
 
-figlet@^1.1.1, figlet@^1.4.0:
+figlet@^1.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.5.0.tgz#2db4d00a584e5155a96080632db919213c3e003c"
   integrity sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww==
@@ -7872,7 +7853,7 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-log4js@^6.2.1, log4js@^6.3.0:
+log4js@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.3.0.tgz#10dfafbb434351a3e30277a00b9879446f715bcb"
   integrity sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==
@@ -9093,14 +9074,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-path@^0.12.7:
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
-  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
-  dependencies:
-    process "^0.11.1"
-    util "^0.10.3"
-
 pathval@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
@@ -9204,7 +9177,7 @@ pg@^7.12.1:
     pgpass "1.x"
     semver "4.3.2"
 
-pg@^8.0.3, pg@^8.3.2:
+pg@^8.3.2:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/pg/-/pg-8.5.1.tgz#34dcb15f6db4a29c702bf5031ef2e1e25a06a120"
   integrity sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==
@@ -9408,11 +9381,6 @@ process-on-spawn@^1.0.0:
   integrity sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==
   dependencies:
     fromentries "^1.2.0"
-
-process@^0.11.1:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@^2.0.0:
   version "2.0.3"
@@ -11134,11 +11102,6 @@ typeorm@^0.2.25, typeorm@^0.2.26, typeorm@^0.2.30:
     yargonaut "^1.1.2"
     yargs "^16.0.3"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
-
 typescript@^3.8, typescript@^3.9.3, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
@@ -11239,13 +11202,6 @@ util.promisify@^1.0.0:
     for-each "^0.3.3"
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.1"
-
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
 
 util@^0.12.3:
   version "0.12.3"


### PR DESCRIPTION
This PR adds additional fields to the indexer:
- extrinsicArgs
- extrinsicHash
- data with event params

This eg enables queries of the form 
```gql
query {
	
  substrateEvents(limit: 5, orderBy: blockNumber_DESC, where: {name_eq: "balances.Transfer", data_json: { param2: { value_gt: 15283400000}}}) {
    name
    extrinsicName
    extrinsicArgs
    extrinsicHash
    data
  } 
}
```