### PR TITLE
fix(hydra-typegen): use a dedicated typegen section in the yml config

### DIFF
--- a/packages/hydra-cli/src/templates/scaffold/manifest.yml
+++ b/packages/hydra-cli/src/templates/scaffold/manifest.yml
@@ -7,14 +7,15 @@ dataSource:
   indexerVersion: '0.0.4'
 entities:
   - mappings/lib/generated/**/*.model.js
-metadata:
-  source: wss://rpc.polkadot.io
-  blockHash: '0xab5c9230a7dde8bb90a6728ba4a0165423294dac14336b1443f865b796ff682c'
-events:
-  - balances.Transfer
-calls:
-  - timestamp.set
-outDir: ./mappings/generated/types
+typegen:
+  metadata:
+    source: wss://rpc.polkadot.io
+    blockHash: '0xab5c9230a7dde8bb90a6728ba4a0165423294dac14336b1443f865b796ff682c'
+  events:
+    - balances.Transfer
+  calls:
+    - timestamp.set
+  outDir: ./mappings/generated/types
 mappings:
   hydraCommonVersion: '0.0.3'
   mappingsModule: mappings/lib/mappings

--- a/packages/hydra-typegen/src/commands/typegen/index.ts
+++ b/packages/hydra-typegen/src/commands/typegen/index.ts
@@ -11,7 +11,7 @@ import {
   buildImportsRegistry,
   generateIndex,
 } from '../../generators'
-import { parseConfigFile } from '../../helpers/parse-yaml'
+import { parseConfigFile } from '../../config/parse-yaml'
 
 export type CustomTypes = {
   lib: string // package with types. All custom types will be imported from there

--- a/packages/hydra-typegen/src/config/parse-yaml.ts
+++ b/packages/hydra-typegen/src/config/parse-yaml.ts
@@ -7,18 +7,20 @@ import { IConfig } from '../commands/typegen'
 
 const options = {
   structure: {
-    metadata: {
-      source: 'string',
-      'blockHash?': 'string',
+    typegen: {
+      metadata: {
+        source: 'string',
+        'blockHash?': 'string',
+      },
+      'customTypes?': {
+        lib: 'string',
+        typedefs: 'string',
+      },
+      'events?': ['string'],
+      'calls?': ['string'],
+      outDir: 'string',
+      'strict?': 'boolean',
     },
-    'customTypes?': {
-      lib: 'string',
-      typedefs: 'string',
-    },
-    'events?': ['string'],
-    'calls?': ['string'],
-    outDir: 'string',
-    'strict?': 'boolean',
   },
   onWarning: function (error: unknown, filepath: unknown) {
     logError(filepath + ' has error: ' + error)
@@ -36,10 +38,10 @@ export function parseConfigFile(location: string): IConfig {
       )}`
     )
   }
-  const parsed = YAML.parse(fs.readFileSync(location, 'utf8'))
+  const { typegen } = YAML.parse(fs.readFileSync(location, 'utf8'))
   return {
-    ...parsed,
-    events: parsed.events || [],
-    calls: parsed.calls || [],
+    ...typegen,
+    events: typegen.events || [],
+    calls: typegen.calls || [],
   } as IConfig
 }

--- a/packages/hydra-typegen/test/config.yml
+++ b/packages/hydra-typegen/test/config.yml
@@ -1,8 +1,9 @@
-metadata:
-  source: wss://kusama-rpc.polkadot.io
-  blockHash: '0x45eb7ddd324361adadd4f8cfafadbfb7e0a26393a70a70e5bee6204fc46af62e'
-events:
-  - Balances.Transfer
-calls:
-  - Balances.transfer
-outDir: ./generated
+typegen:
+  metadata:
+    source: wss://kusama-rpc.polkadot.io
+    blockHash: '0x45eb7ddd324361adadd4f8cfafadbfb7e0a26393a70a70e5bee6204fc46af62e'
+  events:
+    - Balances.Transfer
+  calls:
+    - Balances.transfer
+  outDir: ./generated

--- a/packages/sample/manifest.yml
+++ b/packages/sample/manifest.yml
@@ -8,14 +8,15 @@ dataSource:
   indexerVersion: '2.0.1-beta.0'
 entities:
   - mappings/lib/generated/**/*.model.js
-metadata:
-  source: wss://rpc.polkadot.io
-  blockHash: '0xab5c9230a7dde8bb90a6728ba4a0165423294dac14336b1443f865b796ff682c'
-events:
-  - balances.Transfer
-calls:
-  - timestamp.set
-outDir: ./mappings/generated/types
+typegen:
+  metadata:
+    source: wss://rpc.polkadot.io
+    blockHash: '0xab5c9230a7dde8bb90a6728ba4a0165423294dac14336b1443f865b796ff682c'
+  events:
+    - balances.Transfer
+  calls:
+    - timestamp.set
+  outDir: ./mappings/generated/types
 mappings:
   hydraCommonVersion: '2.0.1-beta.0'
   mappingsModule: mappings/lib/mappings

--- a/packages/sample/typegen-polkadot.yml
+++ b/packages/sample/typegen-polkadot.yml
@@ -1,8 +1,9 @@
-metadata:
-  source: wss://rpc.polkadot.io
-  blockHash: '0xab5c9230a7dde8bb90a6728ba4a0165423294dac14336b1443f865b796ff682c'
-events:
-  - Balances.Transfer
-calls:
-  - timestamp.set
-outDir: ./mappings/generated/types
+typegen:
+  metadata:
+    source: wss://rpc.polkadot.io
+    blockHash: '0xab5c9230a7dde8bb90a6728ba4a0165423294dac14336b1443f865b796ff682c'
+  events:
+    - Balances.Transfer
+  calls:
+    - timestamp.set
+  outDir: ./mappings/generated/types

--- a/packages/sample/typegen.template.yml
+++ b/packages/sample/typegen.template.yml
@@ -1,7 +1,8 @@
-metadata:
-  source: ${NODE_URL}
-events:
-  - balances.Transfer
-calls:
-  - timestamp.set
-outDir: ./mappings/generated/types
+typegen:
+  metadata:
+    source: ${NODE_URL}
+  events:
+    - balances.Transfer
+  calls:
+    - timestamp.set
+  outDir: ./mappings/generated/types

--- a/packages/sample/typegen.yml
+++ b/packages/sample/typegen.yml
@@ -1,7 +1,8 @@
-metadata:
-  source: ws://localhost:9000
-events:
-  - balances.Transfer
-calls:
-  - timestamp.set
-outDir: ./mappings/generated/types
+typegen:
+  metadata:
+    source: ws://localhost:9000
+  events:
+    - balances.Transfer
+  calls:
+    - timestamp.set
+  outDir: ./mappings/generated/types


### PR DESCRIPTION
… for typegen

affects: @dzlzv/hydra-cli, @dzlzv/hydra-typegen, sample

BREAKING CHANGE:
typegen config in the manifest.yml should be moved in a separated typegen section