### PR TITLE
hydra-cli scaffold fixes

### DIFF
--- a/packages/hydra-cli/src/templates/scaffold/.dockerignore
+++ b/packages/hydra-cli/src/templates/scaffold/.dockerignore
@@ -1,0 +1,4 @@
+**/node_modules
+**/dist
+**/lib 
+**/generated

--- a/packages/hydra-cli/src/templates/scaffold/README.md
+++ b/packages/hydra-cli/src/templates/scaffold/README.md
@@ -31,6 +31,7 @@ to run the [typegen](https://github.com/Joystream/hydra/tree/master/packages/hyd
 Mappings is a separated TypeScript module created in the mappings folder. The handlers exported by the module should match the ones defined in `manifest.yml` in the mappings section. Once the necessary files are generated, build it with
 
 ```bash
+yarn workspace sample-mappings install
 yarn mappings:build
 ```
 

--- a/packages/hydra-cli/src/templates/scaffold/docker-compose.yml
+++ b/packages/hydra-cli/src/templates/scaffold/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     environment:
       - INDEXER_ENDPOINT_URL=https://sumer-indexer.joystream.app/graphql
       - DB_HOST=db
-      - PROCESSOR_POLL_INTERVAL=300
+      - POLL_INTERVAL_MS=300
       - TYPEORM_HOST=db
       - DEBUG=hydra-processor:*
     command: ["yarn", "processor:start"]

--- a/packages/hydra-cli/src/templates/scaffold/docker/Dockerfile.builder
+++ b/packages/hydra-cli/src/templates/scaffold/docker/Dockerfile.builder
@@ -6,7 +6,7 @@ WORKDIR /home/hydra-builder
 
 COPY ./mappings ./mappings
 COPY ./*.yml ./
-COPY ./package.json ./
+COPY ./*.json ./
 COPY ./*.graphql ./
 COPY ./.env ./
 

--- a/packages/hydra-cli/src/templates/scaffold/docker/Dockerfile.builder
+++ b/packages/hydra-cli/src/templates/scaffold/docker/Dockerfile.builder
@@ -13,6 +13,7 @@ COPY ./.env ./
 RUN yarn 
 RUN yarn codegen 
 RUN yarn typegen 
+RUN yarn workspace sample-mappings install
 RUN yarn mappings:build
 
 RUN yarn workspace query-node install

--- a/packages/hydra-cli/src/templates/scaffold/package.json.mst
+++ b/packages/hydra-cli/src/templates/scaffold/package.json.mst
@@ -7,6 +7,11 @@
     "./generated/*",
     "./mappings"
   ],
+  "nohoist": [
+    "mappings/**",
+    "**/mappings",
+    "**/mappings/**"
+  ],
   "scripts": {
     "build": "yarn clean && yarn codegen",
     "rebuild": "yarn clean:query-node && yarn bootstrap",


### PR DESCRIPTION
Minor fixes and improvements for hydra-cli scaffold:
- copy all json files in Dockerfile.builder (so that type defs are always copied)
- use nohoist and separate yarn install for mappings 
- docker-compose env variable fixes 
- add .dockerignore