### PR TITLE
fix(hydra-cli): ignore generating module import for self referenced e…

### DIFF
--- a/packages/hydra-cli/src/model/relations.ts
+++ b/packages/hydra-cli/src/model/relations.ts
@@ -41,6 +41,11 @@ function addOne2Many(rel: EntityRelationship): void {
     field.name,
     relatedField.nullable
   )
+  // Re-organize relation types if it is a self reference
+  if (field.type === relatedField.type) {
+    rel.field.relation.type = 'otm'
+    rel.relatedField.relation.type = 'mto'
+  }
 }
 
 function addOne2One(rel: EntityRelationship): void {

--- a/packages/hydra-cli/src/model/relations.ts
+++ b/packages/hydra-cli/src/model/relations.ts
@@ -42,7 +42,7 @@ function addOne2Many(rel: EntityRelationship): void {
     relatedField.nullable
   )
   // Re-organize relation types if it is a self reference
-  if (field.type === relatedField.type) {
+  if (field.type === relatedField.type && rel.field.isList) {
     rel.field.relation.type = 'otm'
     rel.relatedField.relation.type = 'mto'
   }

--- a/packages/hydra-cli/test/helpers/Relationships.test.ts
+++ b/packages/hydra-cli/test/helpers/Relationships.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai'
+import * as fs from 'fs-extra'
+import { EnumContextProvider } from '../../src/generate/EnumContextProvider'
+import { ModelRenderer } from '../../src/generate/ModelRenderer'
+import { fromStringSchema } from './model'
+
+describe('Entity Relationships', () => {
+  let generator: ModelRenderer
+  let modelTemplate: string
+  let enumCtxProvider: EnumContextProvider
+
+  before(() => {
+    modelTemplate = fs.readFileSync(
+      './src/templates/entities/model.ts.mst',
+      'utf-8'
+    )
+  })
+
+  it('should not create import statement for self referenced entities', () => {
+    const model = fromStringSchema(`
+    type Member @entity {
+      invitor: Member
+      invitees: [Member!] @derivedFrom(field: "invitor")
+    }`)
+    generator = new ModelRenderer(
+      model,
+      model.lookupEntity('Member'),
+      enumCtxProvider
+    )
+    const rendered = generator.render(modelTemplate)
+    expect(rendered).to.not.include(
+      `import { Member } from '../member/member.model.ts'`
+    )
+  })
+})


### PR DESCRIPTION
It fixes module imports for self relationships.
Example:

```graphql
type Member @entity {
  invitor: Member
  invitees: [Member!] @derivedFrom(field: "invitor")
}
```

The generated `member/member.model.ts` will have a module import statement like this `import {} from '../member/member.model.ts'` which is incorrect.


affects: @dzlzv/hydra-cli