### PR TITLE
fix(hydra-cli): use transpiled js files for query-node 

### DIFF
--- a/packages/hydra-cli/src/codegen/WarthogWrapper.ts
+++ b/packages/hydra-cli/src/codegen/WarthogWrapper.ts
@@ -192,10 +192,6 @@ export default class WarthogWrapper {
     // Fix ts-node-dev error
     pkgFile.scripts['start:dev'] = 'ts-node --type-check src/index.ts'
 
-    // Node does not run the compiled code, so we use ts-node in production...
-    pkgFile.scripts['start:prod'] =
-      'WARTHOG_ENV=production yarn dotenv:generate && ts-node src/index.ts'
-
     const extraDependencies = this.readExtraDependencies()
 
     pkgFile.dependencies = {

--- a/packages/hydra-cli/src/templates/graphql-server/tsconfig.json.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/tsconfig.json.mst
@@ -20,6 +20,6 @@
     "types": ["isomorphic-fetch", "node"],
     "esModuleInterop": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "db/**/*"],
   "exclude": ["node_modules/**/*", "generated/**/*", "tools/**/*"]
 }

--- a/packages/hydra-cli/src/templates/graphql-server/warthog.env.yml
+++ b/packages/hydra-cli/src/templates/graphql-server/warthog.env.yml
@@ -36,6 +36,7 @@ production:
     WARTHOG_DB_ENTITIES: dist/src/**/*.model.js  
     WARTHOG_DB_SUBSCRIBERS: dist/src/**/*.model.js
     WARTHOG_RESOLVERS_PATH: dist/src/**/*.resolver.js
+    WARTHOG_DB_MIGRATIONS: dist/db/migrations/**/*.js
     DEBUG: 'qnode-cli:*'
     <<: *default_env
   

--- a/packages/hydra-cli/src/templates/graphql-server/warthog.env.yml
+++ b/packages/hydra-cli/src/templates/graphql-server/warthog.env.yml
@@ -33,5 +33,9 @@ staging:
 
 production:
     NODE_ENV: production
+    WARTHOG_DB_ENTITIES: dist/src/**/*.model.js  
+    WARTHOG_DB_SUBSCRIBERS: dist/src/**/*.model.js
+    WARTHOG_RESOLVERS_PATH: dist/src/**/*.resolver.js
+    DEBUG: 'qnode-cli:*'
     <<: *default_env
   

--- a/packages/hydra-cli/src/templates/scaffold/package.json.mst
+++ b/packages/hydra-cli/src/templates/scaffold/package.json.mst
@@ -20,7 +20,8 @@
     "clean:query-node": "rm -rf ./generated/graphql-server",
     "processor:start": "DEBUG=${DEBUG} hydra-processor run -e .env",
     "query-node:start:dev": "yarn workspace query-node start:dev",
-    "query-node:start:prod": "yarn workspace query-node start:prod",
+    "query-node:build:prod": "yarn workspace query-node compile",
+    "query-node:start:prod": "dotenv -- yarn workspace query-node start:prod",
     "query-node:configure": "yarn workspace query-node config:dev",
     "db:up": "yarn docker:db:up",
     "db:create": "yarn workspace query-node db:create",
@@ -29,8 +30,8 @@
     "db:schema:migrate": "yarn workspace query-node db:migrate",
     "db:processor:migrate": "hydra-processor migrate -e .env",
     "db:migrate": "yarn db:schema:migrate && yarn db:processor:migrate",
-    "db:bootstrap": "yarn db:create ; yarn db:prepare && yarn db:migrate",
-    "bootstrap": "yarn codegen && yarn db:drop && yarn db:bootstrap",
+    "db:bootstrap": "yarn db:drop; yarn db:create ; yarn db:prepare && yarn db:migrate",
+    "bootstrap": "yarn codegen && yarn db:bootstrap",
     "codegen": "hydra-cli codegen",
     "typegen:configure": "NODE_URL=${NODE_URL:-ws://localhost:9000} envsub typegen.template.yml typegen.yml",
     "typegen": "rm -rf ./mappings/generated && hydra-typegen typegen manifest.yml --debug",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@dzlzv/hydra-cli": "{{{hydraVersion}}}",
     "@dzlzv/hydra-processor": "{{{hydraProcessorVersion}}}",
-    "@dzlzv/hydra-typegen": "{{{hydraTypegenVersion}}}"
+    "@dzlzv/hydra-typegen": "{{{hydraTypegenVersion}}}",
+    "dotenv-cli": "^4.0.0"
   }
 }

--- a/packages/hydra-e2e-tests/Dockerfile
+++ b/packages/hydra-e2e-tests/Dockerfile
@@ -10,13 +10,6 @@ RUN yarn
 
 WORKDIR /home/hydra/packages/hydra-test
 
-#RUN yarn workspace sample-hydra-processor install
+RUN yarn workspace query-node compile
 
-# Overwrite the default files
-#RUN (cd /home/hydra/packages/sample && yarn hydra-cli scaffold -n e2e-test)
-
-# COPY ./schema/schema.graphql /home/hydra/packages/sample/schema.graphql
-# COPY ./schema/mappings /home/hydra/packages/sample/mappings
-# RUN yarn workspace sample build
-#RUN yarn workspace sample mappings:build
 

--- a/packages/hydra-e2e-tests/docker-compose.yml
+++ b/packages/hydra-e2e-tests/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - TYPEORM_PORT=5432
       - INDEXER_ENDPOINT_URL=http://hydra-indexer-gateway:4000/graphql
       - NODE_URL=ws://substrate:9944
-      - PROCESSOR_POLL_INTERVAL=300 # refresh every second 
+      - POLL_INTERVAL_MS=100 # refresh every second 
       - DEBUG=hydra-processor:*
     ports:
       - "3000:3000"


### PR DESCRIPTION
Adds the necessary env variables to warthog `env.yml` so that in the production mode the transpiled js files are used.

affects: @dzlzv/hydra-cli