### PR TITLE
fix(hydra-cli): templating fixes

### DIFF
--- a/packages/hydra-cli/src/generate/ModelRenderer.ts
+++ b/packages/hydra-cli/src/generate/ModelRenderer.ts
@@ -112,7 +112,7 @@ export class ModelRenderer extends AbstractRenderer {
     this.objType.fields.forEach((f) => {
       if (f.isUnion()) {
         variantImports.add(
-          `import { ${f.type} } from '../variants/variants.model'`
+          `import { ${f.type} } from '../variants/variants.model';\n`
         )
       }
       if (f.relation) {


### PR DESCRIPTION
importProps fn in ModelRenderer was missing new line and ';' which was causing error when importing more than one variant

affects: @dzlzv/hydra-cli

ISSUES CLOSED: #328