### PR TITLE
Graphql server bug fixes

### DIFF
--- a/packages/hydra-cli/src/templates/entities/resolver.ts.mst
+++ b/packages/hydra-cli/src/templates/entities/resolver.ts.mst
@@ -98,7 +98,7 @@ export class {{className}}Resolver {
   }
 
   @Query(() => {{className}}, { nullable: true })
-  async {{camelName}}(
+  async {{camelName}}ByUniqueInput(
     @Arg('where') where: {{className}}WhereUniqueInput,
     @Fields() fields: string[]
   ): Promise<{{className}} | null> {
@@ -149,5 +149,6 @@ export class {{className}}Resolver {
       }
       return null;
     }
+
   {{/fieldResolvers}}
 }

--- a/packages/hydra-cli/src/templates/graphql-server/tsconfig.json.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/tsconfig.json.mst
@@ -18,7 +18,8 @@
     "strict": true,
     "strictNullChecks": true,
     "types": ["isomorphic-fetch", "node"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true
   },
   "include": ["src/**/*", "db/**/*"],
   "exclude": ["node_modules/**/*", "generated/**/*", "tools/**/*"]

--- a/packages/hydra-cli/test/helpers/ModelRenderer.test.ts
+++ b/packages/hydra-cli/test/helpers/ModelRenderer.test.ts
@@ -641,7 +641,10 @@ describe('ModelRenderer', () => {
 
     expect(rendered).to.include(`Query(() => Channel, { nullable: true })`)
     expect(rendered).to.include(
-      `async channel(@Arg('where') where: ChannelWhereUniqueInput, @Fields() fields: string[]): Promise<Channel | null>`
+      `async channelByUniqueInput(
+    @Arg('where') where: ChannelWhereUniqueInput,
+    @Fields() fields: string[]
+  ): Promise<Channel | null>`
     )
     expect(rendered).to.include(
       `this.service.find(where, undefined, 1, 0, fields)`


### PR DESCRIPTION
This PR 
- enables the `declaration: true` flag for `generated/graphql-server/tsconfig.json` for successful compilation
- fixes duplicate function name issue: when entity name is uncountable there will be two functions with the same name e.g `VideoMediaMetadata`. The issue is fixed by adding an additional `*ByUniqueInput` at the end of the type name for the unique query resolver. 