### PR TITLE
feat(typegen): tuple return type for event.params

### DIFF
--- a/packages/hydra-cli/src/templates/scaffold/mappings/mappings.ts
+++ b/packages/hydra-cli/src/templates/scaffold/mappings/mappings.ts
@@ -14,9 +14,9 @@ export async function balancesTransfer(
   event: Balances.TransferEvent
 ) {
   const transfer = new Transfer()
-  transfer.from = Buffer.from(event.data.accountIds[0].toHex())
-  transfer.to = Buffer.from(event.data.accountIds[1].toHex())
-  transfer.value = event.data.balance.toBn()
+  transfer.from = Buffer.from(event.params[0].toHex())
+  transfer.to = Buffer.from(event.params[1].toHex())
+  transfer.value = event.params[2].toBn()
   transfer.block = event.ctx.blockNumber
   transfer.comment = `Transferred ${transfer.value} from ${transfer.from} to ${transfer.to}`
   transfer.insertedAt = new Date()

--- a/packages/hydra-e2e-tests/fixtures/mappings/mappings.ts
+++ b/packages/hydra-e2e-tests/fixtures/mappings/mappings.ts
@@ -2,12 +2,12 @@ import { DatabaseManager } from '@dzlzv/hydra-db-utils'
 import BN from 'bn.js'
 import { SubstrateEvent } from '@dzlzv/hydra-common'
 
-import { Transfer } from '../generated/graphql-server/src/modules/transfer/transfer.model'
-import { BlockTimestamp } from '../generated/graphql-server/src/modules/block-timestamp/block-timestamp.model'
 import {
+  Transfer,
+  BlockTimestamp,
   BlockHook,
   HookType,
-} from '../generated/graphql-server/src/modules/block-hook/block-hook.model'
+} from '../generated/graphql-server/model'
 
 // run 'NODE_URL=<RPC_ENDPOINT> EVENTS=<comma separated list of events> yarn codegen:mappings-types'
 // to genenerate typescript classes for events, such as Balances.TransferEvent
@@ -19,9 +19,10 @@ export async function balancesTransfer(
   event: Balances.TransferEvent
 ) {
   const transfer = new Transfer()
-  transfer.from = Buffer.from(event.data.accountIds[0].toHex())
-  transfer.to = Buffer.from(event.data.accountIds[1].toHex())
-  transfer.value = event.data.balance.toBn()
+  const [from, to, value] = event.params
+  transfer.from = Buffer.from(from.toHex())
+  transfer.to = Buffer.from(to.toHex())
+  transfer.value = value.toBn()
   transfer.block = event.ctx.blockNumber
   transfer.comment = `Transferred ${transfer.value} from ${transfer.from} to ${transfer.to}`
   transfer.insertedAt = new Date()

--- a/packages/hydra-typegen/src/generators/helpers.spec.ts
+++ b/packages/hydra-typegen/src/generators/helpers.spec.ts
@@ -1,10 +1,26 @@
 import { expect } from 'chai'
-import { nameFromType } from '.'
+import { helper } from './helpers'
+import { compact as c } from '../util'
 
 describe('helpers', () => {
-  it('should name from arg type', () => {
-    expect(nameFromType('Compact<Balance> & Codec')).to.equal('balance')
-    expect(nameFromType('MyLongType & Codec')).to.equal('myLongType')
-    expect(nameFromType('SimpleType')).to.equal('simpleType')
+  it('should render return type ', () => {
+    const prmsReturn = helper.paramsReturnType.bind({
+      args: ['Type1', 'Type2 & Codec', 'Option<Type3>'],
+    })
+    expect(c(prmsReturn())).to.equal(
+      c(`[Type1, Type2 & Codec, Option<Type3>]`)
+    )
+  })
+
+  it('should render return type statement', () => {
+    const prmsReturnStmt = helper.paramsReturnStmt.bind({
+      args: ['Type1', 'Type2 & Balance'],
+    })
+    expect(c(prmsReturnStmt())).to.equal(
+      c(`return [createTypeUnsafe<Type1 & Codec>(
+            typeRegistry, 'Type1', [this.ctx.params[0].value]), 
+            createTypeUnsafe<Type2 & Balance & Codec>(
+            typeRegistry, 'Type2 & Balance', [this.ctx.params[1].value])]`)
+    )
   })
 })

--- a/packages/hydra-typegen/src/generators/helpers.spec.ts
+++ b/packages/hydra-typegen/src/generators/helpers.spec.ts
@@ -7,9 +7,7 @@ describe('helpers', () => {
     const prmsReturn = helper.paramsReturnType.bind({
       args: ['Type1', 'Type2 & Codec', 'Option<Type3>'],
     })
-    expect(c(prmsReturn())).to.equal(
-      c(`[Type1, Type2 & Codec, Option<Type3>]`)
-    )
+    expect(c(prmsReturn())).to.equal(c(`[Type1, Type2 & Codec, Option<Type3>]`))
   })
 
   it('should render return type statement', () => {

--- a/packages/hydra-typegen/src/generators/helpers.ts
+++ b/packages/hydra-typegen/src/generators/helpers.ts
@@ -6,54 +6,11 @@ import { warn } from '../log'
 
 const debug = require('debug')('hydra-typegen:helpers')
 
-export const handlebars = Handlebars.create()
-
 const callArgValueGetter = (ctxIndex: number) =>
   `[this.extrinsic.args[${ctxIndex}].value]`
 
 const eventParamValueGetter = (ctxIndex: number) =>
   `[this.ctx.params[${ctxIndex}].value]`
-
-handlebars.registerHelper({
-  imports() {
-    const { imports } = (this as unknown) as { imports: ImportsDef }
-    return renderImports(imports)
-  },
-
-  kebabCase(s: string) {
-    return kebabCase(s)
-  },
-
-  camelCase(s: string) {
-    return camelCase(s)
-  },
-
-  pascalCase(s: string) {
-    return upperFirst(camelCase(s))
-  },
-
-  toString(s: any) {
-    if (s.toString !== undefined) {
-      return s.toString()
-    }
-    return JSON.stringify(s)
-  },
-
-  getters() {
-    const { args } = (this as unknown) as { args: string[] | Arg[] }
-    return isNamedArgs(args)
-      ? renderNamedArgs(args, callArgValueGetter)
-      : renderTypeOnlyArgs(args, eventParamValueGetter)
-  },
-})
-
-function isNamedArgs(args: string[] | Arg[]): args is Arg[] {
-  if (args.length === 0) {
-    warn(`WARNING: empty arguments list`)
-    return true
-  }
-  return 'name' in (args[0] as any)
-}
 
 export function renderImports(imports: ImportsDef): string {
   const defs = Object.keys(imports).map((loc: string) => ({
@@ -90,57 +47,14 @@ export function renderNamedArgs(
   }, '')
 }
 
-export function renderTypeOnlyArgs(
-  argTypes: string[],
-  ctxValueGetter: (ctxIndex: number) => string
-): string {
-  debug(`Rendering type only args: ${JSON.stringify(argTypes, null, 2)}`)
-
-  const grouped = countBy(argTypes)
-  const typeToIndices: Record<string, number[]> = {}
-
-  argTypes.forEach((a, i) => {
-    if (typeToIndices[a]) {
-      typeToIndices[a].push(i)
-    } else {
-      typeToIndices[a] = [i]
-    }
-  })
-
-  return argTypes.reduce((result, argType: string, index) => {
-    let getStmt = ''
-
-    if (grouped[argType] === 1) {
-      getStmt = `get ${nameFromType(argType)}(): ${argType} {
-        return ${renderCreateTypeStmt(argType, ctxValueGetter(index))}
-      }`
-      // once we at the last index of that type
-    } else if (index === last(typeToIndices[argType])) {
-      getStmt =
-        // prettier-ignore
-        `get ${nameFromType(argType)}s(): { [key: number]: ${argType} } {
-          return {
-            ${renderCreateTypesArray(argType, typeToIndices[argType], ctxValueGetter)}
-          }
-        }`
-    }
-    return `${result}\n${getStmt}\n`
-  }, '')
-}
-
-function renderCreateTypesArray(
-  argType: string,
-  indices: number[],
-  ctxValueGetter: (ctxIndex: number) => string
-) {
-  return indices.reduce(
-    (result, argIndex, i) =>
-      `${result}${i}: ${renderCreateTypeStmt(
-        argType,
-        ctxValueGetter(argIndex)
-      )},\n`,
-    ''
+export function renderTypedParams(argTypes: string[]) {
+  const returnType = `[${argTypes.join(',')}]`
+  const returnObjects = argTypes.map((argType, index) =>
+    renderCreateTypeStmt(argType, eventParamValueGetter(index))
   )
+  return `get params(): ${returnType} {
+    return [${returnObjects.join(',')}]
+  }`
 }
 
 function renderCreateTypeStmt(argType: string, ctxValueGetter: string) {
@@ -148,28 +62,54 @@ function renderCreateTypeStmt(argType: string, ctxValueGetter: string) {
             typeRegistry, '${argType}', ${ctxValueGetter}) `
 }
 
-export function inferName(arg: string | Arg): string {
-  if (typeof arg === 'string') {
-    return nameFromType(arg)
-  }
+export const helper: Handlebars.HelperDeclareSpec = {
+  imports() {
+    const { imports } = (this as unknown) as { imports: ImportsDef }
+    return renderImports(imports)
+  },
 
-  if (arg.name !== undefined) {
-    return arg.name.toString()
-  }
+  kebabCase(s: string) {
+    return kebabCase(s)
+  },
 
-  return nameFromType(arg.type.toRawType())
+  camelCase(s: string) {
+    return camelCase(s)
+  },
+
+  pascalCase(s: string) {
+    return upperFirst(camelCase(s))
+  },
+
+  toString(s: any) {
+    if (s.toString !== undefined) {
+      return s.toString()
+    }
+    return JSON.stringify(s)
+  },
+
+  paramsReturnType() {
+    const { args } = (this as unknown) as { args: string[] }
+    return `[${args.join(',')}]`
+  },
+
+  paramsReturnStmt() {
+    const { args } = (this as unknown) as { args: string[] }
+    const returnObjects = args.map((argType, index) =>
+      renderCreateTypeStmt(argType, eventParamValueGetter(index))
+    )
+    return `return [${returnObjects.join(',\n')}]`
+  },
+
+  paramGetter() {
+    const { args } = (this as unknown) as { args: string[] }
+    return renderTypedParams(args)
+  },
+
+  namedGetters() {
+    const { args } = (this as unknown) as { args: Arg[] }
+    return renderNamedArgs(args, callArgValueGetter)
+  },
 }
 
-export function nameFromType(rawType: string): string {
-  let stripped = rawType.trim()
-  if (stripped.includes('&')) {
-    // if its a union type, take only the first part as it's
-    // probably most descriptive
-    stripped = stripped.split('&')[0].trim()
-  }
-  const match = /[^<]*<([^>]+)>.*/g.exec(stripped)
-  if (match && match[1]) {
-    stripped = match[1]
-  }
-  return camelCase(stripped)
-}
+export const handlebars = Handlebars.create()
+handlebars.registerHelper(helper)

--- a/packages/hydra-typegen/src/generators/helpers.ts
+++ b/packages/hydra-typegen/src/generators/helpers.ts
@@ -1,8 +1,7 @@
 import Handlebars from 'handlebars'
 import { ImportsDef } from './types'
-import { kebabCase, countBy, last, camelCase, upperFirst } from 'lodash'
+import { kebabCase, camelCase, upperFirst } from 'lodash'
 import { Arg } from '../metadata'
-import { warn } from '../log'
 
 const debug = require('debug')('hydra-typegen:helpers')
 
@@ -47,7 +46,7 @@ export function renderNamedArgs(
   }, '')
 }
 
-export function renderTypedParams(argTypes: string[]) {
+export function renderTypedParams(argTypes: string[]): string {
   const returnType = `[${argTypes.join(',')}]`
   const returnObjects = argTypes.map((argType, index) =>
     renderCreateTypeStmt(argType, eventParamValueGetter(index))
@@ -80,6 +79,7 @@ export const helper: Handlebars.HelperDeclareSpec = {
     return upperFirst(camelCase(s))
   },
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toString(s: any) {
     if (s.toString !== undefined) {
       return s.toString()

--- a/packages/hydra-typegen/src/metadata/default-types.ts
+++ b/packages/hydra-typegen/src/metadata/default-types.ts
@@ -4,16 +4,10 @@ import * as genericClasses from '@polkadot/types/generic'
 import * as primitiveClasses from '@polkadot/types/primitive'
 import * as interfaceDefinitions from '@polkadot/types/interfaces/definitions'
 
-import { Json, Raw } from '@polkadot/types/codec'
-
-const primitive = {
-  ...primitiveClasses,
-  Json,
-  Raw,
-}
+const primitive = [...Object.keys(primitiveClasses), 'Json', 'Raw']
 
 export const builtInClasses = [
-  ...Object.keys(primitive),
+  ...primitive,
   ...Object.keys(codecClasses as Record<string, unknown>),
   ...Object.keys(genericClasses as Record<string, unknown>),
   ...Object.keys(extrinsicClasses as Record<string, unknown>),

--- a/packages/hydra-typegen/src/metadata/metadata.ts
+++ b/packages/hydra-typegen/src/metadata/metadata.ts
@@ -89,6 +89,7 @@ async function fromChain(
         )
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       websocket.onmessage = (message: any): void => {
         const data = JSON.parse(message.data)
         if (data.error) {

--- a/packages/hydra-typegen/src/templates/module.hbs
+++ b/packages/hydra-typegen/src/templates/module.hbs
@@ -21,7 +21,7 @@ export namespace {{module.name}} {
 
         constructor(public readonly ctx: SubstrateEvent) {}
 
-        get data(): {{name}}_Params {
+        get params(): {{{paramsReturnType}}} {
             
             {{#if @root.validateArgs}}
             if (!this.validateParams()) {
@@ -29,7 +29,7 @@ export namespace {{module.name}} {
             }
             {{/if}}
 
-            return new {{name}}_Params(this.ctx)
+            {{{paramsReturnStmt}}}
         }
 
         validateParams(): boolean {
@@ -47,13 +47,7 @@ export namespace {{module.name}} {
 
     }     
 
-    class {{name}}_Params {
     
-        constructor(public readonly ctx: SubstrateEvent) {}
-
-        {{{getters}}}
-        
-    }
 {{/each}}
 
 {{#each calls}}
@@ -102,7 +96,7 @@ export namespace {{module.name}} {
     
         constructor(public readonly extrinsic: SubstrateExtrinsic) {}
 
-        {{{getters}}}
+        {{{namedGetters}}}
         
     }
 {{/each}}

--- a/packages/hydra-typegen/src/util.ts
+++ b/packages/hydra-typegen/src/util.ts
@@ -67,3 +67,13 @@ export function pushToDictionary<V>(
     dict[key].push(...values)
   }
 }
+
+/**
+ * replace all whitespaces and carriage returns
+ *
+ * @param s
+ * @returns the same string with all whitecharacters removed
+ */
+export function compact(s: string): string {
+  return s.replace(/\s/g, '')
+}

--- a/packages/sample/mappings/mappings.ts
+++ b/packages/sample/mappings/mappings.ts
@@ -14,25 +14,24 @@ import { SubstrateEvent } from '@dzlzv/hydra-common'
 
 const start = Date.now()
 let blockTime = 0
-let blockStartTime = 0
 let totalEvents = 0
 let totalBlocks = 0
 
 export async function balancesTransfer({
   store,
   event,
-  block,
 }: {
   store: DatabaseManager
   event: SubstrateEvent
   block: { blockNumber: number }
 }) {
   const transfer = new Transfer()
-  const _event = new Balances.TransferEvent(event)
-  transfer.from = Buffer.from(_event.data.accountIds[0].toHex())
-  transfer.to = Buffer.from(_event.data.accountIds[1].toHex())
-  transfer.value = _event.data.balance.toBn()
-  transfer.block = block.blockNumber
+  const [from, to, value] = new Balances.TransferEvent(event).params
+  transfer.from = Buffer.from(from.toHex())
+  transfer.to = Buffer.from(to.toHex())
+  transfer.value = value.toBn()
+
+  transfer.block = event.blockNumber
   transfer.comment = `Transferred ${transfer.value} from ${transfer.from} to ${transfer.to}`
   transfer.insertedAt = new Date()
   await store.save<Transfer>(transfer)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2312,6 +2312,11 @@
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.2.tgz#9390a8127c0dcba61ebd7fdcc748655e191bdd68"
   integrity sha512-/5O7Fq6Vnv8L6ucmPjaWbVG1XkP4FO+w5glqfkIsq3Xw4oyNAdJddbnYodNDAfjVUvo/rrSCTom4kAND7T1o5Q==
 
+"@sqltools/formatter@^1.2.2":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.3.tgz#1185726610acc37317ddab11c3c7f9066966bd20"
+  integrity sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg==
+
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -2938,6 +2943,11 @@
   integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@types/zen-observable@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
+  integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
 "@typescript-eslint/eslint-plugin@3.8.0":
   version "3.8.0"
@@ -4136,6 +4146,14 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bufferutil@^4.0.1:
   version "4.0.3"
@@ -7926,7 +7944,7 @@ ieee754@1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ieee754@^1.1.13, ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -11730,10 +11748,24 @@ pg-connection-string@^2.4.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
   integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
 
+pg-format@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/pg-format/-/pg-format-1.0.4.tgz#27734236c2ad3f4e5064915a59334e20040a828e"
+  integrity sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=
+
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-listen@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/pg-listen/-/pg-listen-1.7.0.tgz#5a5c68a1cabf88d2b78ed9cf133667f597d3b860"
+  integrity sha512-MKDwKLm4ryhy7iq1yw1K1MvUzBdTkaT16HZToddX9QaT8XSdt3Kins5mYH6DLECGFzFWG09VdXvWOIYogjXrsg==
+  dependencies:
+    debug "^4.1.1"
+    pg-format "^1.0.4"
+    typed-emitter "^0.1.0"
 
 pg-packet-stream@^1.1.0:
   version "1.1.0"
@@ -14033,7 +14065,7 @@ ts-mockito@^2.6.1:
   dependencies:
     lodash "^4.17.5"
 
-ts-node-dev@^1.0.0-pre.40, ts-node-dev@^1.0.0-pre.63:
+ts-node-dev@^1.0.0-pre.40, ts-node-dev@^1.0.0-pre.60, ts-node-dev@^1.0.0-pre.63:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.1.6.tgz#ee2113718cb5a92c1c8f4229123ad6afbeba01f8"
   integrity sha512-RTUi7mHMNQospArGz07KiraQcdgUVNXKsgO2HAi7FoiyPMdTDqdniB6K1dqyaIxT7c9v/VpSbfBZPS6uVpaFLQ==
@@ -14064,7 +14096,7 @@ ts-node@^7.0.1:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-ts-node@^8:
+ts-node@^8, ts-node@^8.10:
   version "8.10.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
   integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
@@ -14131,6 +14163,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.21.0"
@@ -14238,6 +14275,11 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d"
   integrity sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==
 
+typed-emitter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-0.1.0.tgz#ca532f100ccbf850e3a73b8ebf43d43e4f1f3849"
+  integrity sha512-Tfay0l6gJMP5rkil8CzGbLthukn+9BN/VXWcABVFPjOoelJ+koW8BuPZYk+h/L+lEeIp1fSzVRiWRPIjKVjPdg==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -14281,6 +14323,29 @@ typeorm@^0.2.25, typeorm@^0.2.26:
     xml2js "^0.4.23"
     yargonaut "^1.1.2"
     yargs "^16.0.3"
+
+typeorm@^0.2.31:
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.32.tgz#544dbfdfe0cd0887548d9bcbd28527ea4f4b3c9b"
+  integrity sha512-LOBZKZ9As3f8KRMPCUT2H0JZbZfWfkcUnO3w/1BFAbL/X9+cADTF6bczDGGaKVENJ3P8SaKheKmBgpt5h1x+EQ==
+  dependencies:
+    "@sqltools/formatter" "^1.2.2"
+    app-root-path "^3.0.0"
+    buffer "^6.0.3"
+    chalk "^4.1.0"
+    cli-highlight "^2.1.10"
+    debug "^4.3.1"
+    dotenv "^8.2.0"
+    glob "^7.1.6"
+    js-yaml "^4.0.0"
+    mkdirp "^1.0.4"
+    reflect-metadata "^0.1.13"
+    sha.js "^2.4.11"
+    tslib "^2.1.0"
+    xml2js "^0.4.23"
+    yargonaut "^1.1.4"
+    yargs "^16.2.0"
+    zen-observable-ts "^1.0.0"
 
 typescript@^3.8, typescript@^3.9.3, typescript@^3.9.7:
   version "3.9.9"
@@ -15153,7 +15218,7 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargonaut@^1.1.2:
+yargonaut@^1.1.2, yargonaut@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/yargonaut/-/yargonaut-1.1.4.tgz#c64f56432c7465271221f53f5cc517890c3d6e0c"
   integrity sha512-rHgFmbgXAAzl+1nngqOcwEljqHGG9uUZoPjsdZEs1w5JW9RXYzrSvH/u70C1JE5qFi0qjsdhnUX/dJRpWqitSA==
@@ -15366,7 +15431,15 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0:
+zen-observable-ts@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.0.0.tgz#30d1202b81d8ba4c489e3781e8ca09abf0075e70"
+  integrity sha512-KmWcbz+9kKUeAQ8btY8m1SsEFgBcp7h/Uf3V5quhan7ZWdjGsf0JcGLULQiwOZibbFWnHkYq8Nn2AZbJabovQg==
+  dependencies:
+    "@types/zen-observable" "^0.8.2"
+    zen-observable "^0.8.15"
+
+zen-observable@^0.8.0, zen-observable@^0.8.15:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Fixes https://github.com/Joystream/hydra/issues/336

The typed events generated by typegen should now will look like 
```
get params(): [Type1, Type2, Type3] {
    return [ createType('Type1', ...), createType('Type2', ...), createType('Type3', ...)]
}
```

This fixes some bugs and inconveniences related to the naming based on the types.
