### PR TITLE
Hydra processor check version

### DIFF
--- a/packages/hydra-processor/src/ingest/GraphQLSource.ts
+++ b/packages/hydra-processor/src/ingest/GraphQLSource.ts
@@ -35,6 +35,7 @@ query {
   indexerStatus {
     head
     chainHeight
+    hydraVersion
   }
 }
 `
@@ -58,7 +59,7 @@ export class GraphQLSource implements IProcessorSource {
     throw new Error('Method not implemented.')
   }
 
-  async indexerStatus(): Promise<IndexerStatus> {
+  async getIndexerStatus(): Promise<IndexerStatus> {
     const status = await this.graphClient.request<{
       indexerStatus: IndexerStatus
     }>(GET_INDEXER_STATUS)

--- a/packages/hydra-processor/src/ingest/IProcessorSource.ts
+++ b/packages/hydra-processor/src/ingest/IProcessorSource.ts
@@ -132,7 +132,7 @@ export interface IProcessorSource {
     }
   ): Promise<{ [K in keyof T]: (T[K] & AsJson<T[K]>)[] }>
 
-  indexerStatus(): Promise<IndexerStatus>
+  getIndexerStatus(): Promise<IndexerStatus>
 
   subscribe(events: string[]): Promise<void>
 

--- a/packages/hydra-processor/src/ingest/index.ts
+++ b/packages/hydra-processor/src/ingest/index.ts
@@ -6,7 +6,7 @@ let eventSource: GraphQLSource
 
 export * from './IProcessorSource'
 
-export async function getEventSource(): Promise<IProcessorSource> {
+export async function getProcessorSource(): Promise<IProcessorSource> {
   if (!eventSource) {
     // just to make it async, do some async init here if needed
     await pImmediate()

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -2,7 +2,7 @@
 import { logError } from '@dzlzv/hydra-common'
 import Debug from 'debug'
 
-import { IStateKeeper, getStateKeeper } from '../state'
+import { IStateKeeper, getStateKeeper, IProcessorState } from '../state'
 import { error, info } from '../util/log'
 import { BlockData, getEventQueue, IEventQueue } from '../queue'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
@@ -22,6 +22,9 @@ export class MappingsProcessor {
     this.mappingsExecutor = await getMappingExecutor()
     this.eventQueue = await getEventQueue()
     this.stateKeeper = await getStateKeeper()
+  
+
+
 
     await Promise.all([this.eventQueue.start(), this.processingLoop()])
   }

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -2,7 +2,7 @@
 import { logError } from '@dzlzv/hydra-common'
 import Debug from 'debug'
 
-import { IStateKeeper, getStateKeeper, IProcessorState } from '../state'
+import { IStateKeeper, getStateKeeper } from '../state'
 import { error, info } from '../util/log'
 import { BlockData, getEventQueue, IEventQueue } from '../queue'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
@@ -22,9 +22,6 @@ export class MappingsProcessor {
     this.mappingsExecutor = await getMappingExecutor()
     this.eventQueue = await getEventQueue()
     this.stateKeeper = await getStateKeeper()
-  
-
-
 
     await Promise.all([this.eventQueue.start(), this.processingLoop()])
   }

--- a/packages/hydra-processor/src/start/ProcessorRunner.ts
+++ b/packages/hydra-processor/src/start/ProcessorRunner.ts
@@ -9,6 +9,7 @@ import { getManifest } from './config'
 import { error, info } from '../util/log'
 import pWaitFor from 'p-wait-for'
 import { Server } from 'http'
+import { getHydraVersion } from '../state/version'
 
 const debug = Debug('hydra-processor:runner')
 
@@ -23,12 +24,7 @@ export class ProcessorRunner {
   private promServer: Server | undefined
 
   constructor() {
-    // TODO: a bit hacky, but okay for now
-    debug(
-      `Hydra processor lib version: ${
-        process.env.npm_package_dependencies__dzlzv_hydra_processor || 'UNKNOWN'
-      }`
-    )
+    info(`Hydra processor lib version: ${getHydraVersion()}`)
     // Hook into application
     // eslint-disable-next-line
     process.on('exit', () =>

--- a/packages/hydra-processor/src/start/config.ts
+++ b/packages/hydra-processor/src/start/config.ts
@@ -58,7 +58,7 @@ export function configure(): void {
     BLOCK_WINDOW: num({ default: 100000 }),
     PROCESSOR_NAME: str({ default: 'hydra-processor' }),
     BATCH_SIZE: num({ default: 10 }),
-    POLL_INTERVAL_MS: num({ default: 60 * 1000 }),
+    POLL_INTERVAL_MS: num({ default: 500 }),
     MIN_BLOCKS_AHEAD: num({ default: 0 }),
     MAPPINGS_FACTOR: num({ default: 1 }),
     QUEUE_FACTOR: num({ default: 2 }),

--- a/packages/hydra-processor/src/state/IStateKeeper.ts
+++ b/packages/hydra-processor/src/state/IStateKeeper.ts
@@ -8,6 +8,7 @@ export interface IProcessorState {
 export interface IndexerStatus {
   head: number
   chainHeight: number
+  hydraVersion: string
 }
 
 export interface IStateKeeper {

--- a/packages/hydra-processor/src/state/version.ts
+++ b/packages/hydra-processor/src/state/version.ts
@@ -23,7 +23,6 @@ export function validateIndexerVersion(
   indexerVersion: string,
   indexerVersionRange: string
 ): void {
-
   if (
     !semver.satisfies(indexerVersion, indexerVersionRange, {
       loose: true,

--- a/packages/hydra-processor/src/state/version.ts
+++ b/packages/hydra-processor/src/state/version.ts
@@ -1,0 +1,66 @@
+import semver from 'semver'
+import Debug from 'debug'
+import fs from 'fs'
+
+const debug = Debug('hydra-processor:util')
+
+export const PROCESSOR_PACKAGE_NAME = '@dzlzv/hydra-processor'
+
+export function validateHydraVersion(hydraVersion: string): void {
+  const oursHydraVersion = getHydraVersion()
+  if (
+    !semver.satisfies(oursHydraVersion, hydraVersion, {
+      loose: true,
+      includePrerelease: true,
+    })
+  ) {
+    throw new Error(`The processor version ${oursHydraVersion} does \\
+not satisfy the required manifest version ${hydraVersion}`)
+  }
+}
+
+export function validateIndexerVersion(
+  indexerVersion: string,
+  indexerVersionRange: string
+): void {
+
+  if (
+    !semver.satisfies(indexerVersion, indexerVersionRange, {
+      loose: true,
+      includePrerelease: true,
+    })
+  ) {
+    throw new Error(`The indexer version range ${indexerVersionRange} does \\
+not satisfy the manifest version ${indexerVersion}`)
+  }
+}
+
+export function getHydraVersion(): string {
+  return resolvePackageVersion(PROCESSOR_PACKAGE_NAME)
+}
+
+/**
+ * resolve a package version by resolving package.json
+ *
+ * @param pkgName dependency to loockup
+ */
+export function resolvePackageVersion(pkgName: string): string {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const path = require.resolve(`${PROCESSOR_PACKAGE_NAME}/package.json`)
+  const pkgJson = JSON.parse(fs.readFileSync(path, 'utf-8')) as Record<
+    string,
+    unknown
+  >
+  debug(`Resolved package.json: ${JSON.stringify(pkgJson, null, 2)}`)
+
+  if (pkgName === PROCESSOR_PACKAGE_NAME) {
+    return pkgJson.version as string
+  }
+
+  if (pkgJson.dependencies) {
+    const deps = pkgJson.dependencies as Record<string, string>
+    if (deps[pkgName]) return deps[pkgName]
+  }
+
+  throw new Error(`Can't resolve ${pkgName} version`)
+}

--- a/packages/hydra-processor/src/util/utils.ts
+++ b/packages/hydra-processor/src/util/utils.ts
@@ -1,9 +1,4 @@
-import Debug from 'debug'
-import fs from 'fs'
 import { Range } from '../start/manifest'
-
-const debug = Debug('hydra-processor:util')
-
 
 export function parseEventId(
   eventId: string

--- a/packages/hydra-processor/src/util/utils.ts
+++ b/packages/hydra-processor/src/util/utils.ts
@@ -3,33 +3,7 @@ import fs from 'fs'
 import { Range } from '../start/manifest'
 
 const debug = Debug('hydra-processor:util')
-export const PROCESSOR_PACKAGE_NAME = '@dzlzv/hydra-processor'
 
-/**
- * resolve a package version by resolving package.json
- *
- * @param pkgName dependency to loockup
- */
-export function resolvePackageVersion(pkgName: string): string {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const path = require.resolve(`${PROCESSOR_PACKAGE_NAME}/package.json`)
-  const pkgJson = JSON.parse(fs.readFileSync(path, 'utf-8')) as Record<
-    string,
-    unknown
-  >
-  debug(`Resolved package.json: ${JSON.stringify(pkgJson, null, 2)}`)
-
-  if (pkgName === PROCESSOR_PACKAGE_NAME) {
-    return pkgJson.version as string
-  }
-
-  if (pkgJson.dependencies) {
-    const deps = pkgJson.dependencies as Record<string, string>
-    if (deps[pkgName]) return deps[pkgName]
-  }
-
-  throw new Error(`Can't resolve ${pkgName} version`)
-}
 
 export function parseEventId(
   eventId: string

--- a/packages/sample/.env
+++ b/packages/sample/.env
@@ -48,8 +48,8 @@ INDEXER_ENDPOINT_URL=http://localhost:4001/graphql
 # Block height from which the processor starts. Note that if 
 # there are already processed events in the database, this setting is ignored
 BLOCK_HEIGHT=100000
-BATCH_SIZE=10
-BLOCK_WINDOW=100
+BATCH_SIZE=5000
+BLOCK_WINDOW=10000
 
 
 ###############################

--- a/packages/sample/README.md
+++ b/packages/sample/README.md
@@ -57,6 +57,18 @@ and the GraphQL server (opens a GraphQL playground at localhost by default):
 yarn query-node:start:dev
 ```
 
+## Locally run indexer and indexer-gateway
+
+Run
+
+```bash
+yarn indexer:start:dev
+```
+
+It will build local images for `hydra-indexer` and `hydra-indexer-gateway` and run the docker-compose stack defined in `docker-compose-indexer-dev.yml`
+
+To run the processor against the local indexer, make sure  `INDEXER_ENDPOINT_URL` is set to the local indexer-gateway (`http://localhost:4001/graphql` by default).
+
 ## Custom chains
 
 If there is no public Hydra Indexer readily available, one should set-up a self-hosted [indexer](../hydra-indexer/README.md) and [indexer-api-gateway](../hydra-indexer-gateway/README.md). The simplest way is set it up is to run pre-built docker images for `indexer` and `indexer-api-gateway` as defined in `docker-compose.yml`.

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -9,7 +9,7 @@
   "description": "GraphQL-based query node and Substrate processor. Generated with ♥ by Hydra-CLI",
   "scripts": {
     "build": "yarn clean && yarn codegen",
-    "rebuild": "yarn db:drop && yarn clean:query-node && yarn codegen:query-node && yarn db:prepare && yarn db:migrate",
+    "rebuild": "yarn db:drop ; yarn clean:query-node && yarn codegen && yarn db:prepare && yarn db:migrate",
     "lint": "echo \"Skippinng\"",
     "clean": "rm -rf ./generated",
     "clean:query-node": "rm -rf ./generated/graphql-server",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,16 +2005,7 @@
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
-"@polkadot/keyring@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-6.1.1.tgz#937103e3c98bb92942f91502577fcc3b6bcd4aef"
-  integrity sha512-gpOJ8L7MyuFe9/bYOJ+0qIXZIqob1IMl1xrsULTlF03ijENv7XvMeUUf6hN8hbxkgEWugow060M7SUnLQ4zTTA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@polkadot/util" "6.1.1"
-    "@polkadot/util-crypto" "6.1.1"
-
-"@polkadot/keyring@^6.0.5":
+"@polkadot/keyring@6.0.5", "@polkadot/keyring@6.1.1", "@polkadot/keyring@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-6.0.5.tgz#b684f354476e96c657a7e8d3e5f0c090e1178b31"
   integrity sha512-v9Tmu+eGZnWpLzxHUj5AIvmfX0uCHWShtF90zvaLvMXLFRWfeuaFnZwdZ+fNkXsrbI0R/w1gRtpFqzsT7QUbVw==
@@ -2041,13 +2032,6 @@
   integrity sha512-QSa5RdK43yD4kLsZ6tXIB652bZircaVPOpsZ5JFzxCM4gdxHCSCUeXNVBeh3uqeB3FOZZYzSYeoZHLaXuT3yJw==
   dependencies:
     "@babel/runtime" "^7.13.9"
-
-"@polkadot/networks@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-6.1.1.tgz#7725b75a421e80ad6bc152c6ba0e0b5f82153939"
-  integrity sha512-QJynYW/S00UT9R59w+RPPhUG7zCQURqCDwyJQWKc+yWxnVacBFKvtokrCbYZIViE1lMY4FvdA6blUT3eYmABYg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
 
 "@polkadot/rpc-core@4.2.1":
   version "4.2.1"
@@ -2129,28 +2113,6 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util-crypto@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-6.1.1.tgz#dc9ee86656bbaf59b41c5a1cf40fa025b44aaf27"
-  integrity sha512-xKDqudvMCirQZ4df2PiWEdlNntNn5gUx/2gTNId7MoE4j4y0edLTwiQ6B2EgRCyLxCaIY+sw6Z5NL5ik1NHdcw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@polkadot/networks" "6.1.1"
-    "@polkadot/util" "6.1.1"
-    "@polkadot/wasm-crypto" "^4.0.2"
-    "@polkadot/x-randomvalues" "6.1.1"
-    base-x "^3.0.8"
-    base64-js "^1.5.1"
-    blakejs "^1.1.0"
-    bn.js "^4.11.9"
-    create-hash "^1.2.0"
-    elliptic "^6.5.4"
-    hash.js "^1.1.7"
-    js-sha3 "^0.8.0"
-    scryptsy "^2.1.0"
-    tweetnacl "^1.0.3"
-    xxhashjs "^0.2.2"
-
 "@polkadot/util@6.0.5", "@polkadot/util@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-6.0.5.tgz#aa52995d3fe998eed218d26b243832a7a3e2944d"
@@ -2159,19 +2121,6 @@
     "@babel/runtime" "^7.13.9"
     "@polkadot/x-textdecoder" "6.0.5"
     "@polkadot/x-textencoder" "6.0.5"
-    "@types/bn.js" "^4.11.6"
-    bn.js "^4.11.9"
-    camelcase "^5.3.1"
-    ip-regex "^4.3.0"
-
-"@polkadot/util@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-6.1.1.tgz#d4ab0bf8f0d38f60b93124e7efb4339c16d0b1a1"
-  integrity sha512-xdm2UF6SIjW50jnIyzT1+m1sLBjulExDAo+7JnrTZe4OQfUL8JyQzJ3jdy9hFNBHjXkLRENc94DR4HSJ+n3Uyg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@polkadot/x-textdecoder" "6.1.1"
-    "@polkadot/x-textencoder" "6.1.1"
     "@types/bn.js" "^4.11.6"
     bn.js "^4.11.9"
     camelcase "^5.3.1"
@@ -2200,7 +2149,7 @@
     "@polkadot/wasm-crypto-asmjs" "^4.0.2"
     "@polkadot/wasm-crypto-wasm" "^4.0.2"
 
-"@polkadot/x-fetch@^6.0.5":
+"@polkadot/x-fetch@6.0.5", "@polkadot/x-fetch@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-6.0.5.tgz#b6c90c478f9951ab1f9c835d48869c669c45120e"
   integrity sha512-LuyIxot8pLnYaYsR1xok7Bjm+s7wxYe27Y66THea6bDL3CrBPQdj74F9i0OIxD1GB+qJqh4mDApiGX3COqssvg==
@@ -2219,15 +2168,6 @@
     "@types/node-fetch" "^2.5.8"
     node-fetch "^2.6.1"
 
-"@polkadot/x-global@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-6.1.1.tgz#c9dab736cb0ff3274bebabeb5a9f1c57d126b73c"
-  integrity sha512-h/5K2i8S7oteQITD2aF3Scxd7uOPH4HaBk/DDiM7M89TvzMp+QLISkBapK2boAKRejceKULuKlFVKFGzryF1NA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@types/node-fetch" "^2.5.10"
-    node-fetch "^2.6.1"
-
 "@polkadot/x-randomvalues@6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-6.0.5.tgz#32aa5e670acf3ab13af281f9c0871c279de24b0a"
@@ -2236,15 +2176,7 @@
     "@babel/runtime" "^7.13.9"
     "@polkadot/x-global" "6.0.5"
 
-"@polkadot/x-randomvalues@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-6.1.1.tgz#e57a31bc51513c88fd8228a24a154b5e426dcff1"
-  integrity sha512-b6IFmV64YdyWwWYnnqD/piQALRA4Xs/eQklBaldoBzg/INTWx8sA3M43HUOZlmcY4TLNAOG8mBxzrDmsFj3Ezw==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@polkadot/x-global" "6.1.1"
-
-"@polkadot/x-rxjs@^6.0.5":
+"@polkadot/x-rxjs@6.0.5", "@polkadot/x-rxjs@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-6.0.5.tgz#829b12f225a4252ae16e405fe7876cce390eabd6"
   integrity sha512-nwMaP69/RzdXbPn8XypIRagMpW46waSraQq4/tGb4h+/Qob+RHxCT68UHKz1gp7kzxhrf85LanE9410A6EYjRw==
@@ -2260,14 +2192,6 @@
     "@babel/runtime" "^7.13.9"
     "@polkadot/x-global" "6.0.5"
 
-"@polkadot/x-textdecoder@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-6.1.1.tgz#b19bfc375224c8c4069a6d69bc813419b1715942"
-  integrity sha512-z4a91pNkD6WNDp+Jl4nf6kLM5ZM1x5Zmrrs2qDmX3WP+/okJUb5J+RYXSDnPnKeuoyQHHV0cNuWos5nQZxmmrA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@polkadot/x-global" "6.1.1"
-
 "@polkadot/x-textencoder@6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-6.0.5.tgz#fc851259de97a98f3417e51807c1f5ebe265fdf0"
@@ -2276,15 +2200,7 @@
     "@babel/runtime" "^7.13.9"
     "@polkadot/x-global" "6.0.5"
 
-"@polkadot/x-textencoder@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-6.1.1.tgz#1963034091398e93465ec2709d68ced88008a62e"
-  integrity sha512-NLL9HxigxKeI30X89z40m6DWu1RrL9mZvXwLbl5Se1ditNsOK5/3+gBSlLqZiuB7LuY0YJCCbkqMSp/mAANglA==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@polkadot/x-global" "6.1.1"
-
-"@polkadot/x-ws@^6.0.5":
+"@polkadot/x-ws@6.0.5", "@polkadot/x-ws@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-6.0.5.tgz#bafab6004d88d9273478332a3a040bfef3647619"
   integrity sha512-J2vUfDjWIwEB/FSIXKZxER2flWqRvWcxvAaN+w6dhxJw8BKl+NYKN8QRrlhcDvbk/PWEEtdjthwV3lyOoeGDLA==
@@ -2819,7 +2735,7 @@
   resolved "https://registry.yarnpkg.com/@types/node-emoji/-/node-emoji-1.8.1.tgz#689cb74fdf6e84309bcafce93a135dfecd01de3f"
   integrity sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==
 
-"@types/node-fetch@2.5.10", "@types/node-fetch@^2.5.10", "@types/node-fetch@^2.5.8":
+"@types/node-fetch@2.5.10", "@types/node-fetch@^2.5.8":
   version "2.5.10"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
   integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
@@ -11919,10 +11835,24 @@ pg-connection-string@^2.4.0, pg-connection-string@^2.5.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
 
+pg-format@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/pg-format/-/pg-format-1.0.4.tgz#27734236c2ad3f4e5064915a59334e20040a828e"
+  integrity sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=
+
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-listen@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/pg-listen/-/pg-listen-1.7.0.tgz#5a5c68a1cabf88d2b78ed9cf133667f597d3b860"
+  integrity sha512-MKDwKLm4ryhy7iq1yw1K1MvUzBdTkaT16HZToddX9QaT8XSdt3Kins5mYH6DLECGFzFWG09VdXvWOIYogjXrsg==
+  dependencies:
+    debug "^4.1.1"
+    pg-format "^1.0.4"
+    typed-emitter "^0.1.0"
 
 pg-packet-stream@^1.1.0:
   version "1.1.0"
@@ -14242,7 +14172,7 @@ ts-mockito@^2.6.1:
   dependencies:
     lodash "^4.17.5"
 
-ts-node-dev@^1.0.0-pre.40, ts-node-dev@^1.0.0-pre.63:
+ts-node-dev@^1.0.0-pre.40, ts-node-dev@^1.0.0-pre.60, ts-node-dev@^1.0.0-pre.63:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.1.6.tgz#ee2113718cb5a92c1c8f4229123ad6afbeba01f8"
   integrity sha512-RTUi7mHMNQospArGz07KiraQcdgUVNXKsgO2HAi7FoiyPMdTDqdniB6K1dqyaIxT7c9v/VpSbfBZPS6uVpaFLQ==
@@ -14273,7 +14203,7 @@ ts-node@^7.0.1:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-ts-node@^8:
+ts-node@^8, ts-node@^8.10:
   version "8.10.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
   integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
@@ -14452,6 +14382,11 @@ type@^2.0.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d"
   integrity sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==
 
+typed-emitter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-0.1.0.tgz#ca532f100ccbf850e3a73b8ebf43d43e4f1f3849"
+  integrity sha512-Tfay0l6gJMP5rkil8CzGbLthukn+9BN/VXWcABVFPjOoelJ+koW8BuPZYk+h/L+lEeIp1fSzVRiWRPIjKVjPdg==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -14474,7 +14409,7 @@ typeorm-typedi-extensions@^0.2.3:
   resolved "https://registry.yarnpkg.com/typeorm-typedi-extensions/-/typeorm-typedi-extensions-0.2.3.tgz#94fca2656206d771bf6d2242f5aab570511188e8"
   integrity sha512-T9i1NvRZNjPn9Jb8oT772ihfn6PwdqDVpzPCtKSqjkZGOgXrCkdyD3dDrzfMaoWJ1afU58bVx2CMb95FzT42Ow==
 
-typeorm@^0.2.25, typeorm@^0.2.26:
+typeorm@^0.2.25, typeorm@^0.2.26, typeorm@^0.2.31:
   version "0.2.32"
   resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.32.tgz#544dbfdfe0cd0887548d9bcbd28527ea4f4b3c9b"
   integrity sha512-LOBZKZ9As3f8KRMPCUT2H0JZbZfWfkcUnO3w/1BFAbL/X9+cADTF6bczDGGaKVENJ3P8SaKheKmBgpt5h1x+EQ==


### PR DESCRIPTION
This PR:
- checks version compatibility between Hydra Indexer and Hydra Processor
- improves performance by waiting until new blocks are produced by the indexer
- minor fixes for `sample` yarn scripts