### PR TITLE
Hooks without events

### DIFF
--- a/packages/hydra-e2e-tests/fixtures/manifest.yml
+++ b/packages/hydra-e2e-tests/fixtures/manifest.yml
@@ -29,6 +29,9 @@ mappings:
       handler: timestampCall
   preBlockHooks:
     - handler: preHook
+      filter:
+        height: '[0,0]'
+    - handler: preHook
       filter: 
         height: '[1, 2]'
   postBlockHooks:

--- a/packages/hydra-e2e-tests/test/e2e/hooks.test.ts
+++ b/packages/hydra-e2e-tests/test/e2e/hooks.test.ts
@@ -28,7 +28,7 @@ describe('end-to-end hook tests', () => {
     const preHooks = hooks
       .filter((h) => h.type === 'PRE')
       .map((h) => h.blockNumber)
-    expect(preHooks).to.have.members([1, 2])
+    expect(preHooks).to.have.members([0, 1, 2])
   })
 
   it('finds post hooks', async () => {

--- a/packages/hydra-processor/src/executor/MappingsLookupService.ts
+++ b/packages/hydra-processor/src/executor/MappingsLookupService.ts
@@ -11,7 +11,7 @@ import {
 
 import { BlockData, EventData, Kind } from '../queue'
 import { getConfig as conf } from '../start/config'
-import { isInRange } from '../util/utils'
+import { isInRange } from '../util'
 import {
   MappingContext,
   EventContext,

--- a/packages/hydra-processor/src/ingest/IProcessorSource.ts
+++ b/packages/hydra-processor/src/ingest/IProcessorSource.ts
@@ -138,5 +138,5 @@ export interface IProcessorSource {
 
   getBlock(blockNumber: number): Promise<SubstrateBlock>
 
-  fetchBlocks(heights: number[]): Promise<void>
+  fetchBlocks(heights: number[]): Promise<SubstrateBlock[]>
 }

--- a/packages/hydra-processor/src/process/MappingsProcessor.ts
+++ b/packages/hydra-processor/src/process/MappingsProcessor.ts
@@ -4,14 +4,15 @@ import Debug from 'debug'
 
 import { IStateKeeper, getStateKeeper } from '../state'
 import { error, info } from '../util/log'
-import { BlockData, getEventQueue, IEventQueue } from '../queue'
+import { BlockData, getBlockQueue, IBlockQueue } from '../queue'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
 import { getMappingExecutor, IMappingExecutor, isTxAware } from '../executor'
+import { getManifest } from '../start/config'
 const debug = Debug('hydra-processor:mappings-processor')
 
 export class MappingsProcessor {
   private _started = false
-  private eventQueue!: IEventQueue
+  private eventQueue!: IBlockQueue
   private stateKeeper!: IStateKeeper
   private mappingsExecutor!: IMappingExecutor
 
@@ -20,7 +21,7 @@ export class MappingsProcessor {
     this._started = true
 
     this.mappingsExecutor = await getMappingExecutor()
-    this.eventQueue = await getEventQueue()
+    this.eventQueue = await getBlockQueue()
     this.stateKeeper = await getStateKeeper()
 
     await Promise.all([this.eventQueue.start(), this.processingLoop()])
@@ -43,35 +44,32 @@ export class MappingsProcessor {
         // in the requested blocks, so we simply fast-forward `lastScannedBlock`
         debug('awaiting')
 
-        const next = await this.eventQueue.blocks().next()
+        const next = await this.eventQueue.blocksWithEvents().next()
 
+        // range of heights where there might be blocks with hooks
+        const hookLookupRange = {
+          from: this.stateKeeper.getState().lastScannedBlock + 1,
+          to: next.done
+            ? getManifest().mappings.range.to
+            : next.value.block.height - 1,
+        }
+
+        // process blocks with hooks that preceed the event block
+        for await (const b of this.eventQueue.blocksWithHooks(
+          hookLookupRange
+        )) {
+          await this.processBlock(b)
+        }
+
+        // now process the block with events
         if (next.done === true) {
           info('All the blocks from the queue have been processed')
           break
         }
 
-        const nextBlock = next.value
+        const eventBlock = next.value
 
-        debug(
-          `Next block: ${nextBlock.block.id}, events count: ${nextBlock.events.length} `
-        )
-
-        await this.mappingsExecutor.executeBlock(
-          nextBlock,
-          async (ctx: BlockData) => {
-            await this.stateKeeper.updateState(
-              { lastScannedBlock: ctx.block.height },
-              // update the state in the same transaction if the tx context is present
-              isTxAware(ctx) ? ctx.entityManager : undefined
-            )
-          }
-        )
-        // emit all at once
-        nextBlock.events.map((ctx) =>
-          eventEmitter.emit(ProcessorEvents.PROCESSED_EVENT, ctx.event)
-        )
-
-        debug(`Done block ${nextBlock.block.height}`)
+        await this.processBlock(eventBlock)
       } catch (e) {
         error(`Stopping the proccessor due to errors: ${logError(e)}`)
         this.stop()
@@ -79,6 +77,29 @@ export class MappingsProcessor {
       }
     }
     info(`Terminating the processor`)
+  }
+
+  private async processBlock(nextBlock: BlockData) {
+    info(
+      `Processing block: ${nextBlock.block.id}, events count: ${nextBlock.events.length} `
+    )
+
+    await this.mappingsExecutor.executeBlock(
+      nextBlock,
+      async (ctx: BlockData) => {
+        await this.stateKeeper.updateState(
+          { lastScannedBlock: ctx.block.height },
+          // update the state in the same transaction if the tx context is present
+          isTxAware(ctx) ? ctx.entityManager : undefined
+        )
+      }
+    )
+    // emit all at once
+    nextBlock.events.map((ctx) =>
+      eventEmitter.emit(ProcessorEvents.PROCESSED_EVENT, ctx.event)
+    )
+
+    debug(`Done block ${nextBlock.block.height}`)
   }
 
   private shouldWork(): boolean {

--- a/packages/hydra-processor/src/queue/BlockQueue.spec.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.spec.ts
@@ -1,13 +1,13 @@
-import { EventQueue } from './EventQueue'
+import { BlockQueue } from './BlockQueue'
 import { expect } from 'chai'
-import { RangeFilter, MappingFilter } from './IEventQueue'
+import { RangeFilter, MappingFilter } from './IBlockQueue'
 import { IndexerStatus, IProcessorState, IStateKeeper } from '../state'
 import { formatEventId } from '@dzlzv/hydra-common'
 import { getConfig as conf } from '../start/config'
 
 describe('EventQueue', () => {
   it('should properly set the initial filter', () => {
-    const eventQueue: EventQueue = new EventQueue()
+    const eventQueue: BlockQueue = new BlockQueue()
     eventQueue.stateKeeper = ({
       getState: () => {
         return {
@@ -39,7 +39,7 @@ describe('EventQueue', () => {
   })
 
   it('should update the next block range', () => {
-    const eventQueue: EventQueue = new EventQueue()
+    const eventQueue: BlockQueue = new BlockQueue()
 
     eventQueue.rangeFilter = ({
       block: {

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -1,7 +1,7 @@
 import { getProcessorSource } from '../ingest'
 import { getConfig as conf, getManifest } from '../start/config'
 import { info } from '../util/log'
-import { uniq, last, first, union, mapValues } from 'lodash'
+import { uniq, last, first, union, mapValues, _ } from 'lodash'
 import pWaitFor from 'p-wait-for'
 import delay from 'delay'
 import Debug from 'debug'
@@ -20,8 +20,7 @@ import { MappingsDef } from '../start/manifest'
 import { SubstrateEvent } from '@dzlzv/hydra-common'
 import { IndexerQuery, IProcessorSource } from '../ingest/IProcessorSource'
 import { parseEventId } from '../util/utils'
-import { unionAll, Range, unionWith, numbersIn, intersectWith } from '../util'
-import _ from 'lodash'
+import { unionAll, Range, numbersIn, intersectWith } from '../util'
 
 const debug = Debug('hydra-processor:event-queue')
 
@@ -282,8 +281,8 @@ export class BlockQueue implements IBlockQueue {
     const chunks = _.chunk(heights, conf().BATCH_SIZE)
 
     for (const c of chunks) {
-      let blocks = await this.dataSource.fetchBlocks(c)
-      for (let block of blocks) {
+      const blocks = await this.dataSource.fetchBlocks(c)
+      for (const block of blocks) {
         yield { block, events: [] }
       }
     }

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -10,16 +10,18 @@ import { IndexerStatus, IStateKeeper, getStateKeeper } from '../state'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
 import {
   BlockData,
-  IEventQueue,
+  IBlockQueue,
   MappingFilter,
   Kind,
   RangeFilter,
   EventData,
-} from './IEventQueue'
+} from './IBlockQueue'
 import { MappingsDef } from '../start/manifest'
 import { SubstrateEvent } from '@dzlzv/hydra-common'
 import { IndexerQuery, IProcessorSource } from '../ingest/IProcessorSource'
 import { parseEventId } from '../util/utils'
+import { unionAll, Range, unionWith, numbersIn, intersectWith } from '../util'
+import _ from 'lodash'
 
 const debug = Debug('hydra-processor:event-queue')
 
@@ -42,7 +44,7 @@ export function getMappingFilter(mappingsDef: MappingsDef): MappingFilter {
   }
 }
 
-export class EventQueue implements IEventQueue {
+export class BlockQueue implements IBlockQueue {
   _started = false
   _hasNext = true
   indexerStatus!: IndexerStatus
@@ -52,6 +54,7 @@ export class EventQueue implements IEventQueue {
   mappingFilter!: MappingFilter
   rangeFilter!: RangeFilter
   indexerQueries!: { [key in Kind]?: Partial<IndexerQuery> }
+  heightsWithHooks!: Range[]
 
   async init(): Promise<void> {
     info(`Waiting for the indexer head to be initialized`)
@@ -67,6 +70,10 @@ export class EventQueue implements IEventQueue {
 
     this.rangeFilter = this.getInitialRange()
 
+    this.heightsWithHooks = unionAll(
+      getManifest().mappings.preBlockHooks.map((h) => h.filter.height),
+      getManifest().mappings.postBlockHooks.map((h) => h.filter.height)
+    )
     this.indexerQueries = prepareIndexerQueries(this.mappingFilter)
   }
 
@@ -132,7 +139,7 @@ export class EventQueue implements IEventQueue {
     return first(this.eventQueue)
   }
 
-  async *blocks(): AsyncGenerator<BlockData, void, void> {
+  async *blocksWithEvents(): AsyncGenerator<BlockData, void, void> {
     // FIXME: this method only produces blocks with some event.
 
     while (this._started) {
@@ -263,6 +270,25 @@ export class EventQueue implements IEventQueue {
     }
   }
 
+  async *blocksWithHooks(range: Range): AsyncGenerator<BlockData, void, void> {
+    const ranges = intersectWith(range, this.heightsWithHooks)
+
+    debug(`Fetching hooks in ranges: ${JSON.stringify(ranges)}`)
+
+    const heights = ranges
+      .reduce((acc: number[], r) => [...acc, ...numbersIn(r)], [])
+      .sort()
+
+    const chunks = _.chunk(heights, conf().BATCH_SIZE)
+
+    for (const c of chunks) {
+      let blocks = await this.dataSource.fetchBlocks(c)
+      for (let block of blocks) {
+        yield { block, events: [] }
+      }
+    }
+  }
+
   private async fetchNextBatch() {
     const queries = mapValues(
       this.indexerQueries,
@@ -287,6 +313,7 @@ export class EventQueue implements IEventQueue {
 
     if (conf().VERBOSE) debug(`Requesting blocks: ${blockHeights}`)
 
+    // prefetch to the cache
     await this.dataSource.fetchBlocks(blockHeights)
 
     return trimmed

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -1,7 +1,7 @@
 import { getProcessorSource } from '../ingest'
 import { getConfig as conf, getManifest } from '../start/config'
 import { info } from '../util/log'
-import { uniq, last, first, union, mapValues, _ } from 'lodash'
+import { uniq, last, first, union, mapValues, chunk } from 'lodash'
 import pWaitFor from 'p-wait-for'
 import delay from 'delay'
 import Debug from 'debug'
@@ -278,7 +278,7 @@ export class BlockQueue implements IBlockQueue {
       .reduce((acc: number[], r) => [...acc, ...numbersIn(r)], [])
       .sort()
 
-    const chunks = _.chunk(heights, conf().BATCH_SIZE)
+    const chunks = chunk(heights, conf().BATCH_SIZE)
 
     for (const c of chunks) {
       const blocks = await this.dataSource.fetchBlocks(c)

--- a/packages/hydra-processor/src/queue/IBlockQueue.ts
+++ b/packages/hydra-processor/src/queue/IBlockQueue.ts
@@ -1,5 +1,5 @@
 import { SubstrateBlock, SubstrateEvent } from '@dzlzv/hydra-common'
-import { Range } from '../start/manifest'
+import { Range } from '../util'
 
 export enum Kind {
   EXTRINSIC = 'EXTRINSIC',
@@ -8,7 +8,6 @@ export enum Kind {
 }
 
 export interface EventData {
-  // TODO: update interfaces in hydra-common
   event: SubstrateEvent
   kind: Kind
 }
@@ -19,9 +18,10 @@ export interface BlockData {
   events: EventData[]
 }
 
-export interface IEventQueue {
+export interface IBlockQueue {
   isEmpty(): boolean
-  blocks(): AsyncGenerator<BlockData, void, void>
+  blocksWithEvents(): AsyncGenerator<BlockData, void, void>
+  blocksWithHooks(range: Range): AsyncGenerator<BlockData, void, void>
   start(): Promise<void>
   stop(): void
 }
@@ -41,15 +41,6 @@ export interface RangeFilter {
   limit: number // fetch at most that many events
 }
 
-// export interface FilterConfig extends RangeFilter {
-//   events: string[]
-//   extrinsics: {
-//     names: string[]
-//     triggerEvents: string[]
-//   }
-//   blocks: number[]
-// }
-
 /**
  * Describes a set of query filters derived from the
  * mapping definition
@@ -61,6 +52,4 @@ export interface MappingFilter {
     names: string[]
     triggerEvents: string[]
   }
-  // TODO: implement arbitrary block filters
-  // blockHooks: { height?: Range }[]
 }

--- a/packages/hydra-processor/src/queue/index.ts
+++ b/packages/hydra-processor/src/queue/index.ts
@@ -1,14 +1,14 @@
-import { EventQueue } from './EventQueue'
-import { IEventQueue } from './IEventQueue'
+import { BlockQueue } from './BlockQueue'
+import { IBlockQueue } from './IBlockQueue'
 
-export * from './IEventQueue'
+export * from './IBlockQueue'
 
-let eventQueue: EventQueue
+let blockQueue: BlockQueue
 
-export async function getEventQueue(): Promise<IEventQueue> {
-  if (!eventQueue) {
-    eventQueue = new EventQueue()
-    await eventQueue.init()
+export async function getBlockQueue(): Promise<IBlockQueue> {
+  if (!blockQueue) {
+    blockQueue = new BlockQueue()
+    await blockQueue.init()
   }
-  return eventQueue
+  return blockQueue
 }

--- a/packages/hydra-processor/src/start/config.ts
+++ b/packages/hydra-processor/src/start/config.ts
@@ -57,7 +57,7 @@ export function configure(): void {
     PROMETHEUS_PORT: num({ default: 3000 }),
     BLOCK_WINDOW: num({ default: 100000 }),
     PROCESSOR_NAME: str({ default: 'hydra-processor' }),
-    BATCH_SIZE: num({ default: 10 }),
+    BATCH_SIZE: num({ default: 1000 }),
     POLL_INTERVAL_MS: num({ default: 500 }),
     MIN_BLOCKS_AHEAD: num({ default: 0 }),
     MAPPINGS_FACTOR: num({ default: 1 }),

--- a/packages/hydra-processor/src/start/manifest.ts
+++ b/packages/hydra-processor/src/start/manifest.ts
@@ -6,7 +6,7 @@ import semver from 'semver'
 import { camelCase, upperFirst, compact } from 'lodash'
 import Debug from 'debug'
 import { HandlerFunc } from './QueryEventProcessingPack'
-import { parseRange } from '../util/utils'
+import { Range, parseRange } from '../util'
 import { validateHydraVersion } from '../state/version'
 
 export const STORE_CLASS_NAME = 'DatabaseManager'
@@ -117,14 +117,8 @@ export interface MappingsDef {
 }
 
 export interface Filter {
-  height?: Range
+  height: Range
   specVersion?: Range
-}
-
-// inclusive
-export interface Range {
-  from: number
-  to: number
 }
 
 export interface MappingHandler {
@@ -235,6 +229,8 @@ function buildMappingsDef(parsed: MappingsDefInput): MappingsDef {
     unknown
   >
 
+  const globalRange = parseRange(range)
+
   const parseHandler = function (
     def:
       | (HandlerInput & {
@@ -252,7 +248,8 @@ function buildMappingsDef(parsed: MappingsDefInput): MappingsDef {
     return {
       ...def,
       filter: {
-        height: filter && filter.height ? parseRange(filter.height) : undefined,
+        height:
+          filter && filter.height ? parseRange(filter.height) : globalRange,
         specVersion:
           filter && filter.specVersion
             ? parseRange(filter.specVersion)

--- a/packages/hydra-processor/src/state/StateKeeper.ts
+++ b/packages/hydra-processor/src/state/StateKeeper.ts
@@ -8,11 +8,9 @@ import Debug from 'debug'
 import pThrottle from 'p-throttle'
 import { eventEmitter, ProcessorEvents } from '../start/processor-events'
 import { getConfig as conf, getManifest } from '../start/config'
-import { isInRange, parseEventId } from '../util/utils'
+import { isInRange, Range, parseEventId, info, warn } from '../util'
 import { formatEventId, SubstrateEvent } from '@dzlzv/hydra-common'
 import { IndexerStatus } from '.'
-import { info, warn } from '../util/log'
-import { Range } from '../start/manifest'
 import { validateIndexerVersion } from './version'
 const debug = Debug('hydra-processor:processor-state-handler')
 

--- a/packages/hydra-processor/src/util/index.ts
+++ b/packages/hydra-processor/src/util/index.ts
@@ -1,0 +1,3 @@
+export * from './log'
+export * from './utils'
+export * from './ranges'

--- a/packages/hydra-processor/src/util/ranges.spec.ts
+++ b/packages/hydra-processor/src/util/ranges.spec.ts
@@ -1,5 +1,12 @@
 import { expect } from 'chai'
-import { isInRange, parseRange } from './utils'
+import {
+  EMPTY_RANGE,
+  intersect,
+  isInRange,
+  parseRange,
+  unionAll,
+  unionWith,
+} from './ranges'
 
 describe('utils', () => {
   it('should calculate in range', () => {
@@ -56,5 +63,82 @@ describe('utils', () => {
 
     expect(parseRange('(2,3]')).to.include({ from: 3, to: 3 }, '(2,3]')
     expect(parseRange('(-1,3]')).to.include({ from: 0, to: 3 }, '(-1,3]')
+  })
+
+  it('should intersect two ranges', () => {
+    expect(intersect({ from: 0, to: 10 }, { from: 6, to: 11 })).to.deep.eq({
+      from: 6,
+      to: 10,
+    })
+    expect(intersect({ from: 0, to: 5 }, { from: 6, to: 11 })).to.be.eq(
+      EMPTY_RANGE
+    )
+
+    expect(
+      intersect({ from: 0, to: 5 }, { from: 3, to: Number.POSITIVE_INFINITY })
+    ).to.deep.eq({ from: 3, to: 5 })
+
+    expect(intersect({ from: 0, to: 5 }, EMPTY_RANGE)).to.be.eq(EMPTY_RANGE)
+  })
+
+  it('should intersect one range and an aray', () => {
+    expect(
+      unionWith({ from: 3, to: 10 }, [
+        { from: 0, to: 4 },
+        { from: 6, to: 7 },
+        { from: 9, to: 11 },
+      ])
+    ).to.deep.include({
+      from: 0,
+      to: 11,
+    })
+
+    expect(
+      unionWith({ from: 5, to: 10 }, [
+        { from: 0, to: 4 },
+        { from: 6, to: 7 },
+        { from: 9, to: 11 },
+      ])
+    ).to.have.deep.members([
+      { from: 0, to: 4 },
+      { from: 5, to: 11 },
+    ])
+
+    expect(
+      unionWith({ from: 5, to: 10 }, [
+        { from: 0, to: 4 },
+        { from: 6, to: 7 },
+        { from: 9, to: 11 },
+        { from: 13, to: 16 },
+      ])
+    ).to.have.deep.members([
+      {
+        from: 0,
+        to: 4,
+      },
+      { from: 5, to: 11 },
+      { from: 13, to: 16 },
+    ])
+  })
+
+  it('should intersect two range arrays', () => {
+    expect(
+      unionAll(
+        [
+          { from: 1, to: 3 },
+          { from: 5, to: 7 },
+          { from: 9, to: 11 },
+        ],
+        [
+          { from: 0, to: 2 },
+          { from: 4, to: 6 },
+          { from: 8, to: 10 },
+        ]
+      )
+    ).to.have.deep.members([
+      { from: 0, to: 3 },
+      { from: 4, to: 7 },
+      { from: 8, to: 11 },
+    ])
   })
 })

--- a/packages/hydra-processor/src/util/ranges.ts
+++ b/packages/hydra-processor/src/util/ranges.ts
@@ -119,7 +119,7 @@ export function unionWith(range1: Range, ranges: Range[]): Range[] {
  * @param ranges2
  * @returns
  */
-export function unionAll(ranges1: Range[], ranges2: Range[]) {
+export function unionAll(ranges1: Range[], ranges2: Range[]): Range[] {
   const both = [...ranges1, ...ranges2]
     .filter((r) => !isEmpty(r))
     .sort((r1, r2) => r1.from - r2.from)

--- a/packages/hydra-processor/src/util/ranges.ts
+++ b/packages/hydra-processor/src/util/ranges.ts
@@ -1,0 +1,203 @@
+import _ from 'lodash'
+
+/**
+ * A range of intergers, in the interval [from, to], inclusive.
+ */
+export interface Range {
+  from: number
+  to: number
+}
+
+export const EMPTY_RANGE: Range = {
+  from: Number.NEGATIVE_INFINITY,
+  to: Number.NEGATIVE_INFINITY,
+}
+
+export function isEmpty(range: Range): boolean {
+  if (range === EMPTY_RANGE || range.to === Number.NEGATIVE_INFINITY) {
+    return true
+  }
+  const { to, from } = range
+  return to < from
+}
+
+export function intersects(range1: Range, range2: Range): boolean {
+  return !isEmpty(intersect(range1, range2))
+}
+
+export function intersect(range1: Range, range2: Range): Range {
+  if (isEmpty(range1) || isEmpty(range2)) {
+    return EMPTY_RANGE
+  }
+
+  const from = Math.max(range1.from, range2.from)
+  const to = Math.min(range1.to, range2.to)
+
+  return isEmpty({ from, to }) ? EMPTY_RANGE : { from, to }
+}
+
+export function union(range1: Range, range2: Range): Range[] {
+  if (isEmpty(range1) && isEmpty(range2)) {
+    return []
+  }
+  if (isEmpty(range1)) return [range2]
+  if (isEmpty(range2)) return [range1]
+
+  if (intersects(range1, range2)) {
+    return [
+      {
+        from: Math.min(range1.from, range2.from),
+        to: Math.max(range1.to, range2.to),
+      },
+    ]
+  }
+
+  // the ranges don't intersect, return an array of two
+  return [range1, range2].sort((r1, r2) => r1.from - r2.from)
+}
+
+export function intersectWith(range1: Range, ranges: Range[]): Range[] {
+  if (isEmpty(range1)) return []
+  return ranges
+    .filter((r) => intersects(range1, r))
+    .map((r) => intersect(range1, r))
+}
+
+/**
+ * Intersect a range with an array of ranges until none of them overlap
+ *
+ * Implementation note: this is a straighforward implementation with linear complexity
+ *
+ * @param range1
+ * @param ranges
+ * @returns
+ */
+export function unionWith(range1: Range, ranges: Range[]): Range[] {
+  if (ranges.length === 0) {
+    return [range1]
+  }
+
+  let intersectLeftIndex = -1
+  let intersectRightIndex = -1
+
+  let unionRange = range1
+
+  ranges.forEach((r, i) => {
+    if (intersects(r, unionRange)) {
+      intersectLeftIndex = intersectLeftIndex < 0 ? i : intersectLeftIndex
+      intersectRightIndex = i
+      unionRange = union(unionRange, r)[0]
+    }
+  })
+
+  if (intersectLeftIndex < 0) {
+    return [range1, ...ranges].sort((r1, r2) => r1.from - r2.from)
+  }
+
+  if (intersectLeftIndex === 0) {
+    return intersectRightIndex === ranges.length
+      ? [unionRange]
+      : [unionRange, ...ranges.slice(intersectRightIndex + 1)]
+  }
+
+  return intersectRightIndex === ranges.length
+    ? [...ranges.slice(0, intersectLeftIndex), unionRange]
+    : [
+        ...ranges.slice(0, intersectLeftIndex),
+        unionRange,
+        ...ranges.slice(intersectRightIndex + 1),
+      ]
+}
+
+/**
+ * Take pairwise union of two range arrays until not of them overlap
+ *
+ * Implementation note: the running complexity is a product of the array length and may be slow
+ * for very large arrays
+ *
+ * @param ranges1
+ * @param ranges2
+ * @returns
+ */
+export function unionAll(ranges1: Range[], ranges2: Range[]) {
+  const both = [...ranges1, ...ranges2]
+    .filter((r) => !isEmpty(r))
+    .sort((r1, r2) => r1.from - r2.from)
+
+  if (both.length === 0) {
+    return []
+  }
+
+  return both
+    .reduce((acc: Range[], r) => unionWith(r, acc), [both[0]])
+    .sort((r1, r2) => r1.from - r2.from)
+}
+
+/**
+ * checks if the given height is within a given range, [from, to] (inclusive)
+ * By convention anything is withing the undefined range
+ * @param height
+ * @param range
+ * @returns
+ */
+export function isInRange(height: number, range: Range | undefined): boolean {
+  if (range === undefined) {
+    return true
+  }
+  const { from, to } = range
+  return from <= height && height <= to
+}
+
+export function stringify({ from, to }: Range): string {
+  return `[${from}, ${to}]`
+}
+
+export function numbersIn({ from, to }: Range): number[] {
+  if (
+    from === Number.NEGATIVE_INFINITY ||
+    to === Number.POSITIVE_INFINITY ||
+    from - to > 100_000_000
+  ) {
+    throw new Error(`The range [${from}, ${to}] is too large`)
+  }
+  return _.range(from, to + 1, 1)
+}
+
+/**
+ * parses an interval. Square bracket mean inclusive, curly braces mean exclusive
+ * @param range string of the form [<number>, <number>]
+ * @throw throws if the range is empty or if theere's a parsing error
+ */
+export function parseRange(range: string | undefined): Range {
+  const defaultEmpty = {
+    from: 0,
+    to: Number.POSITIVE_INFINITY,
+  }
+  if (range === undefined) {
+    return defaultEmpty
+  }
+
+  const trimmed = range.trim().replace(/\s/g, '')
+  if (!trimmed.match(/^[[(]-?\d*,-?\d*[)\]]$/)) {
+    throw new Error(`Malformed range: ${range}`)
+  }
+
+  const split = trimmed.replace(/[[()\]]/g, '').split(',')
+  let left = split[0].length === 0 ? 0 : Number.parseInt(split[0])
+  let right =
+    split[1].length === 0 ? Number.POSITIVE_INFINITY : Number.parseInt(split[1])
+
+  if (split[0].length !== 0 && trimmed.includes('(')) {
+    left++
+  }
+
+  if (Number.isFinite(right) && trimmed.includes(')')) {
+    right--
+  }
+
+  if (left > right) {
+    throw new Error(`The range ${range} is empty`)
+  }
+
+  return { from: left, to: right }
+}

--- a/packages/hydra-processor/src/util/utils.ts
+++ b/packages/hydra-processor/src/util/utils.ts
@@ -1,5 +1,3 @@
-import { Range } from '../start/manifest'
-
 export function parseEventId(
   eventId: string
 ): { blockHeight: number; eventId: number; hash?: string } {
@@ -43,58 +41,4 @@ export function format(s: string): string {
 
 export function compact(s: string): string {
   return s.replace(/\s/g, '')
-}
-
-/**
- * checks if the given height is within a given range, [from, to] (inclusive)
- * By convention anything is withing the undefined range
- * @param height
- * @param range
- * @returns
- */
-export function isInRange(height: number, range: Range | undefined): boolean {
-  if (range === undefined) {
-    return true
-  }
-  const { from, to } = range
-  return from <= height && height <= to
-}
-
-/**
- * parses an interval. Square bracket mean inclusive, curly braces mean exclusive
- * @param range string of the form [<number>, <number>]
- * @throw throws if the range is empty or if theere's a parsing error
- */
-export function parseRange(range: string | undefined): Range {
-  const defaultEmpty = {
-    from: 0,
-    to: Number.POSITIVE_INFINITY,
-  }
-  if (range === undefined) {
-    return defaultEmpty
-  }
-
-  const trimmed = range.trim().replace(/\s/g, '')
-  if (!trimmed.match(/^[[(]-?\d*,-?\d*[)\]]$/)) {
-    throw new Error(`Malformed range: ${range}`)
-  }
-
-  const split = trimmed.replace(/[[()\]]/g, '').split(',')
-  let left = split[0].length === 0 ? 0 : Number.parseInt(split[0])
-  let right =
-    split[1].length === 0 ? Number.POSITIVE_INFINITY : Number.parseInt(split[1])
-
-  if (split[0].length !== 0 && trimmed.includes('(')) {
-    left++
-  }
-
-  if (Number.isFinite(right) && trimmed.includes(')')) {
-    right--
-  }
-
-  if (left > right) {
-    throw new Error(`The range ${range} is empty`)
-  }
-
-  return { from: left, to: right }
 }


### PR DESCRIPTION
Previously, block hooks were executed only for blocks for which there is at least one event handler. In particular, it was impossible to add an initialization hook to the genesis block, as there are no events there and thus it was always skipped. This PR fixes this, giving full control over the heights where the block hooks are executed