### PR TITLE
fix(hydra-cli): fix ts compilation error in generated relationship re…

### DIFF
--- a/packages/hydra-cli/src/templates/entities/resolver.ts.mst
+++ b/packages/hydra-cli/src/templates/entities/resolver.ts.mst
@@ -128,10 +128,10 @@ export class {{className}}Resolver {
               .getMany();
             let {{relatedTsProp}}Ids: string[] = []
             {{#relationType.isOTM}}
-            {{relatedTsProp}}Ids = Array.from(new Set(result.map(v => v.{{relatedTsProp}}.id)));
+            {{relatedTsProp}}Ids = Array.from(new Set(result.map(v => v!.{{relatedTsProp}}!.id)));
             {{/relationType.isOTM}}
             {{#relationType.isMTM}}
-            Array.from(new Set(result.map(v => v.{{relatedTsProp}}.map(c => {{relatedTsProp}}Ids.push(c.id)))));
+            Array.from(new Set(result.map(v => v!.{{relatedTsProp}}!.map(c => {{relatedTsProp}}Ids.push(c.id)))));
             {{/relationType.isMTM}}
 
             delete where.{{fieldName}}_some
@@ -167,7 +167,7 @@ export class {{className}}Resolver {
 
                 // Group entity
                 const g = _.chain(result)
-                  .groupBy(v => v.{{relatedTsProp}}.id)
+                  .groupBy(v => v!.{{relatedTsProp}}!.id)
                   .value();
 
                 // Get all entities with their relations without filtering them

--- a/packages/hydra-e2e-tests/fixtures/schema.graphql
+++ b/packages/hydra-e2e-tests/fixtures/schema.graphql
@@ -2,6 +2,8 @@
 type Transfer @entity {
   from: Bytes!
   to: Bytes!
+  fromAccount: Account
+  toAccount: Account
   value: BigInt!
   comment: String @fulltext(query: "commentSearch")
   block: Int!
@@ -25,6 +27,15 @@ type BlockHook @entity {
 enum HookType {
   PRE
   POST
+}
+
+type Account @entity {
+  "Account address"
+  id: ID!
+  hex: String!
+  balance: BigInt!
+  incoming: [Transfer!] @derivedFrom(field: "toAccount")
+  outgoing: [Transfer!] @derivedFrom(field: "fromAccount")
 }
 
 ############## Test purpose only @hydra-e2e-tests #################

--- a/packages/sample/.env
+++ b/packages/sample/.env
@@ -41,14 +41,13 @@ MAPPINGS_LOCATION=../../mappings
 TYPES_JSON=
 
 # Indexer GraphQL API endpoint to fetch indexed events
-#INDEXER_ENDPOINT_URL=https://indexer-kusama.joystream.app/graphql
-INDEXER_ENDPOINT_URL=http://localhost:4001/graphql
+INDEXER_ENDPOINT_URL=https://indexer-kusama.joystream.app/graphql
 
 
 # Block height from which the processor starts. Note that if 
 # there are already processed events in the database, this setting is ignored
 BLOCK_HEIGHT=100000
-BATCH_SIZE=5000
+BATCH_SIZE=10000
 BLOCK_WINDOW=10000
 
 

--- a/packages/sample/manifest.yml
+++ b/packages/sample/manifest.yml
@@ -34,8 +34,8 @@ mappings:
       handler: balancesTransfer
       filter:
         specVersion: '[0,)'
-  preBlockHooks:
-    - handler: preHook
-  postBlockHooks:
-    - handler: postHook
+  # preBlockHooks:
+  #   - handler: preHook
+  # postBlockHooks:
+  #   - handler: postHook
   

--- a/packages/sample/schema.graphql
+++ b/packages/sample/schema.graphql
@@ -1,13 +1,23 @@
 " All transfers "
 type Transfer @entity {
-  from: Bytes!
-  to: Bytes!
+  from: Account
+  to: Account
   value: BigInt!
   comment: String @fulltext(query: "commentSearch")
   block: Int!
   tip: BigInt!
   timestamp: BigInt!
   insertedAt: DateTime!
+}
+
+
+type Account @entity {
+  "Account address"
+  id: ID!
+  hex: String!
+  balance: BigInt!
+  incoming: [Transfer!] @derivedFrom(field: "to")
+  outgoing: [Transfer!] @derivedFrom(field: "from")
 }
 
 " Tracks block timestamps "


### PR DESCRIPTION
Quick fix for the compilation error when a relationship field is optional, e.g.

```
error TS2532: Object is possibly 'undefined'.
189         invitedByIds = Array.from(new Set(result.map((v) => v.invitedBy.id)));
``` 

becomes

```
error TS2532: Object is possibly 'undefined'.
189         invitedByIds = Array.from(new Set(result.map((v) => v!.invitedBy!.id)));
``` 

Some e2e test with derived relationships are added

affects: @dzlzv/hydra-cli, hydra-e2e-tests, sample, sample-mappings