### PR TITLE
fix(hydra-indexer): do not coerce null to empty string 

### DIFF
--- a/packages/hydra-indexer/src/entities/SubstrateEventEntity.ts
+++ b/packages/hydra-indexer/src/entities/SubstrateEventEntity.ts
@@ -147,7 +147,7 @@ export class SubstrateEventEntity extends AbstractWarthogModel {
 
       e.method.args.forEach((data, index) => {
         const name = e.meta.args[index].name.toString()
-        const value = (data.toJSON() || '') as AnyJsonField
+        const value = data.toJSON() as AnyJsonField
         const type = data.toRawType()
 
         extr.args.push({


### PR DESCRIPTION
Extrinsic args JSON was coerced to an empty string vs null, causing deserialization issues (#393)

affects: @dzlzv/hydra-indexer

ISSUES CLOSED: #393