### PR TITLE
fix(hydra-typegen): do proper handling of tuples in typegen

### DIFF
--- a/packages/hydra-typegen/src/generators/helpers.spec.ts
+++ b/packages/hydra-typegen/src/generators/helpers.spec.ts
@@ -10,6 +10,13 @@ describe('helpers', () => {
     expect(c(prmsReturn())).to.equal(c(`[Type1, Type2 & Codec, Option<Type3>]`))
   })
 
+  it('should render return type with tupes ', () => {
+    const prmsReturn = helper.paramsReturnType.bind({
+      args: ['Type1', 'Vec<(Type1,Type2)>'],
+    })
+    expect(c(prmsReturn())).to.equal(c(`[Type1, Vec<[Type1,Type2] & Codec>]`))
+  })
+
   it('should render return type statement', () => {
     const prmsReturnStmt = helper.paramsReturnStmt.bind({
       args: ['Type1', 'Type2 & Balance'],
@@ -19,6 +26,16 @@ describe('helpers', () => {
             typeRegistry, 'Type1', [this.ctx.params[0].value]), 
             createTypeUnsafe<Type2 & Balance & Codec>(
             typeRegistry, 'Type2 & Balance', [this.ctx.params[1].value])]`)
+    )
+  })
+
+  it('should handle tuple types', () => {
+    const prmsReturnStmt = helper.paramsReturnStmt.bind({
+      args: ['Vec<(Type1,Type2,(Balance1,Balance2))>'],
+    })
+    expect(c(prmsReturnStmt())).to.equal(
+      c(`return [createTypeUnsafe<Vec<[Type1,Type2,[Balance1,Balance2] & Codec] & Codec> & Codec>(
+            typeRegistry, 'Vec<(Type1,Type2,(Balance1,Balance2))>', [this.ctx.params[0].value])]`)
     )
   })
 })


### PR DESCRIPTION
affects: @dzlzv/hydra-typegen

tuples of the form (T1, T2, T3) are recursively replaced with [T1,T2,T3] & Codec

ISSUES CLOSED: #398