### PR TITLE
Interface relation filtering

### DIFF
--- a/packages/hydra-cli/src/generate/ModelRenderer.ts
+++ b/packages/hydra-cli/src/generate/ModelRenderer.ts
@@ -49,10 +49,18 @@ export class ModelRenderer extends AbstractRenderer {
     this.model
       .getSubclasses(this.objType.name)
       .map((o) => subclasses.push(utils.withNames(o)))
-    const interfaceRelations = utils.interfaceRelations(this.objType)
     return {
       subclasses,
-      interfaceRelations,
+    }
+  }
+
+  withInterfaceRelationOptions(): GeneratorContext {
+    if (this.objType.isInterface !== true) {
+      return {}
+    }
+    return {
+      interfaceRelations: utils.interfaceRelations(this.objType),
+      interfaceEnumName: `${this.objType.name}TypeOptions`,
     }
   }
 
@@ -211,6 +219,7 @@ export class ModelRenderer extends AbstractRenderer {
       ...this.withFieldResolvers(),
       ...utils.withNames(this.objType),
       ...this.withVariantNames(),
+      ...this.withInterfaceRelationOptions(),
     }
   }
 }

--- a/packages/hydra-cli/src/generate/ModelRenderer.ts
+++ b/packages/hydra-cli/src/generate/ModelRenderer.ts
@@ -49,8 +49,10 @@ export class ModelRenderer extends AbstractRenderer {
     this.model
       .getSubclasses(this.objType.name)
       .map((o) => subclasses.push(utils.withNames(o)))
+    const interfaceRelations = utils.interfaceRelations(this.objType)
     return {
       subclasses,
+      interfaceRelations,
     }
   }
 

--- a/packages/hydra-cli/src/generate/field-context.ts
+++ b/packages/hydra-cli/src/generate/field-context.ts
@@ -78,15 +78,22 @@ export function buildFieldContext(
 ): GeneratorContext {
   return {
     ...withFieldTypeGuardProps(f),
-    ...withRequired(f),
-    ...withUnique(f),
     ...withRelation(f),
     ...withArrayCustomFieldConfig(f),
     ...withTsTypeAndDecorator(f),
     ...withDerivedNames(f, entity),
-    ...withDescription(f),
     ...withTransformer(f),
-    ...withArrayProp(f),
+    ...withDecoratorOptions(f),
+  }
+}
+
+export function withDecoratorOptions(f: Field): GeneratorContext {
+  return {
+    required: !f.nullable,
+    description: f.description,
+    unique: f.unique,
+    array: f.isList,
+    apiOnly: f.apiOnly,
   }
 }
 
@@ -100,24 +107,6 @@ export function withFieldTypeGuardProps(f: Field): GeneratorContext {
   ;['mto', 'oto', 'otm', 'mtm'].map((s) => (is[s] = f.relation?.type === s))
   return {
     is: is,
-  }
-}
-
-export function withRequired(f: Field): GeneratorContext {
-  return {
-    required: !f.nullable,
-  }
-}
-
-export function withDescription(f: Field): GeneratorContext {
-  return {
-    description: f.description,
-  }
-}
-
-export function withUnique(f: Field): GeneratorContext {
-  return {
-    unique: f.unique,
   }
 }
 
@@ -179,12 +168,6 @@ export function withImport(f: Field): GeneratorContext {
 export function withRelation(f: Field): GeneratorContext {
   return {
     relation: f.relation,
-  }
-}
-
-export function withArrayProp(f: Field): GeneratorContext {
-  return {
-    array: f.isList,
   }
 }
 

--- a/packages/hydra-cli/src/generate/utils.ts
+++ b/packages/hydra-cli/src/generate/utils.ts
@@ -72,7 +72,7 @@ export function interfaceRelations(o: ObjectType): { fieldName: string }[] {
   return o.fields
     .filter((f) => f.isEntity())
     .map((f) => {
-      return { fieldName: toLower(f.name) }
+      return { fieldName: camelCase(f.name) }
     })
 }
 

--- a/packages/hydra-cli/src/generate/utils.ts
+++ b/packages/hydra-cli/src/generate/utils.ts
@@ -2,6 +2,8 @@ import _, { upperFirst, kebabCase, camelCase, snakeCase, toLower } from 'lodash'
 import { GeneratorContext } from './SourcesGenerator'
 import { ObjectType, Field } from '../model'
 import pluralize from 'pluralize'
+import { ModelType } from '../model/WarthogModel'
+import { GraphQLEnumType, GraphQLEnumValueConfigMap } from 'graphql'
 
 export { upperFirst, kebabCase, camelCase }
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
@@ -68,7 +70,7 @@ export function ownFields(o: ObjectType): Field[] {
 
 export function interfaceRelations(o: ObjectType): { fieldName: string }[] {
   return o.fields
-    .filter((f) => !f.isBuildinType)
+    .filter((f) => f.isEntity())
     .map((f) => {
       return { fieldName: toLower(f.name) }
     })
@@ -107,4 +109,39 @@ export function generateResolverReturnType(
  */
 export function compact(s: string): string {
   return s.replace(/\s/g, '')
+}
+
+/**
+ * Generate EnumField for interface filtering; filter interface by implementers
+ * e.g where: {type_in: [Type1, Type2]}
+ */
+export function generateEnumField(typeName: string, apiOnly = true): Field {
+  const enumField = new Field(`type`, typeName)
+  enumField.modelType = ModelType.ENUM
+  enumField.description = 'Filtering options for interface implementers'
+  enumField.isBuildinType = false
+  enumField.apiOnly = apiOnly
+  return enumField
+}
+
+export function generateGraphqlEnumType(
+  name: string,
+  values: GraphQLEnumValueConfigMap
+): GraphQLEnumType {
+  return new GraphQLEnumType({
+    name,
+    values,
+  })
+}
+
+export function generateEnumOptions(
+  options: string[]
+): GraphQLEnumValueConfigMap {
+  // const values: GraphQLEnumValueConfigMap = this._model
+  //   .getSubclasses(i.name)
+
+  return options.reduce((init, option) => {
+    init[option] = { value: option }
+    return init
+  }, {})
 }

--- a/packages/hydra-cli/src/generate/utils.ts
+++ b/packages/hydra-cli/src/generate/utils.ts
@@ -1,4 +1,4 @@
-import _, { upperFirst, kebabCase, camelCase, snakeCase } from 'lodash'
+import _, { upperFirst, kebabCase, camelCase, snakeCase, toLower } from 'lodash'
 import { GeneratorContext } from './SourcesGenerator'
 import { ObjectType, Field } from '../model'
 import pluralize from 'pluralize'
@@ -27,6 +27,7 @@ export function names(name: string): { [key: string]: string } {
     camelName: camelCase(name),
     kebabName: kebabCase(name),
     relClassName: pascalCase(name),
+    typeormAliasName: toLower(name),
     relCamelName: camelCase(name),
     // Not proper pluralization, but good enough and easy to fix in generated code
     camelNamePlural: camelPlural(name),
@@ -63,6 +64,14 @@ export function ownFields(o: ObjectType): Field[] {
     if (!f.isBuildinType && f.relation) fields.push(f)
   })
   return fields
+}
+
+export function interfaceRelations(o: ObjectType): { fieldName: string }[] {
+  return o.fields
+    .filter((f) => !f.isBuildinType)
+    .map((f) => {
+      return { fieldName: toLower(f.name) }
+    })
 }
 
 export function generateJoinColumnName(name: string): string {

--- a/packages/hydra-cli/src/generate/utils.ts
+++ b/packages/hydra-cli/src/generate/utils.ts
@@ -29,7 +29,7 @@ export function names(name: string): { [key: string]: string } {
     camelName: camelCase(name),
     kebabName: kebabCase(name),
     relClassName: pascalCase(name),
-    typeormAliasName: toLower(name),
+    aliasName: toLower(name),
     relCamelName: camelCase(name),
     // Not proper pluralization, but good enough and easy to fix in generated code
     camelNamePlural: camelPlural(name),

--- a/packages/hydra-cli/src/model/Field.ts
+++ b/packages/hydra-cli/src/model/Field.ts
@@ -33,6 +33,8 @@ export class Field {
 
   derivedFrom?: DerivedFrom
 
+  apiOnly?: boolean
+
   constructor(
     name: string,
     type: string,

--- a/packages/hydra-cli/src/model/ObjectType.ts
+++ b/packages/hydra-cli/src/model/ObjectType.ts
@@ -12,4 +12,5 @@ export interface ObjectType {
   description?: string
   isInterface?: boolean
   interfaces?: ObjectType[] // interface names
+  implementers: string[] // List of interface implementer names
 }

--- a/packages/hydra-cli/src/model/ObjectType.ts
+++ b/packages/hydra-cli/src/model/ObjectType.ts
@@ -12,5 +12,5 @@ export interface ObjectType {
   description?: string
   isInterface?: boolean
   interfaces?: ObjectType[] // interface names
-  implementers: string[] // List of interface implementer names
+  implementers?: string[] // List of interface implementer names
 }

--- a/packages/hydra-cli/src/templates/entities/model.ts.mst
+++ b/packages/hydra-cli/src/templates/entities/model.ts.mst
@@ -144,7 +144,8 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
   {{#is.enum}}
     @EnumField('{{tsType}}', {{tsType}}, { 
       {{^required}}nullable: true,{{/required}} 
-      {{#description}}description: `{{{description}}}`{{/description}} })
+      {{#description}}description: `{{{description}}}`{{/description}}
+      {{#apiOnly}}, apiOnly: true {{/apiOnly}} })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}:{{tsType}} 
   {{/is.enum}}
 

--- a/packages/hydra-cli/src/templates/interfaces/resolver.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/resolver.ts.mst
@@ -1,6 +1,7 @@
-import { Arg, Args, Mutation, Query, Resolver } from 'type-graphql';
+import { Arg, Args, Mutation, Query, Resolver, Info } from 'type-graphql';
 import { Inject } from 'typedi';
 import { Fields, StandardDeleteResponse, UserId } from 'warthog';
+import { GraphQLResolveInfo } from 'graphql';
 
 import {
   {{className}}CreateInput,
@@ -21,9 +22,10 @@ export class {{className}}Resolver {
   @Query(() => [{{className}}])
   async {{camelNamePlural}}(
     @Args() { where, orderBy, limit, offset }: {{className}}WhereArgs,
-    @Fields() fields: string[]
+    @Fields() fields: string[],
+    @Info() info?: GraphQLResolveInfo | string
   ): Promise<{{className}}[]> {
-    return this.service.find<{{className}}WhereInput>(where, orderBy, limit, offset, fields);
+    return this.service.find<{{className}}WhereInput>(where, orderBy, limit, offset, fields, info);
   }
 
   

--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -29,6 +29,8 @@ export class {{className}}Service {
 			throw new Error('Limit or offset are too large');
 		}
 
+    const filteredTypes: string[] = where && where.type_in ? where.type_in : [];
+
 		{{#subclasses}}
       let  {{camelNamePlural}}: {{className}}[] = [];
     {{/subclasses}}
@@ -40,8 +42,7 @@ export class {{className}}Service {
           ob,
           _limit + _offset,
           0,
-          undefined,
-          { manager }
+          undefined
         );
       {{/subclasses}}
 
@@ -52,9 +53,17 @@ export class {{className}}Service {
         {{/subclasses}}
       {{/interfaceRelations}}
       
-      {{#subclasses}}
-        {{camelNamePlural}} = await {{camelNamePlural}}Query.getMany();
-      {{/subclasses}}
+      if (filteredTypes.length) {
+        {{#subclasses}}
+          if (filteredTypes.includes('{{className}}')) {
+            {{camelNamePlural}} = await {{camelNamePlural}}Query.getMany();
+          }
+        {{/subclasses}}
+      } else {
+        {{#subclasses}}
+          {{camelNamePlural}} = await {{camelNamePlural}}Query.getMany();
+        {{/subclasses}}
+      }
     })
 
 		let collect: any[] = [{{#subclasses}}...{{camelNamePlural}}, {{/subclasses}}];

--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -13,6 +13,8 @@ import { {{#subclasses}} {{className}}, {{/subclasses}} } from '../../../model';
 
 import { {{className}} } from './{{kebabName}}.model';
 
+import { {{className}}TypeOptions } from '../enums/enums';
+
 @Service('{{className}}Service')
 export class {{className}}Service {
   constructor(
@@ -55,7 +57,7 @@ export class {{className}}Service {
       
       if (filteredTypes.length) {
         {{#subclasses}}
-          if (filteredTypes.includes('{{className}}')) {
+          if (filteredTypes.includes({{interfaceEnumName}}.{{className}})) {
             {{camelNamePlural}} = await {{camelNamePlural}}Query.getMany();
           }
         {{/subclasses}}

--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -2,6 +2,7 @@ import { Service, Inject } from 'typedi';
 import { getConnection, EntityManager } from 'typeorm';
 import { WhereInput } from 'warthog';
 import { isArray, orderBy } from 'lodash';
+import { GraphQLResolveInfo } from 'graphql';
 
 {{#subclasses}}
 import { {{className}}Service } from '../{{kebabName}}/{{kebabName}}.service'
@@ -23,7 +24,36 @@ export class {{className}}Service {
     {{/subclasses}}
   ) {}
 
-  async find<W extends WhereInput>(where?: any, ob?: string | string[], limit?: number, offset?: number, fields?: string[]): Promise<{{className}}[]> {
+  // TODO: Move to utils
+  requestedRelations(_info: GraphQLResolveInfo) {
+    const relations: { [key: string]: boolean } = {};
+    [{{#interfaceRelations}}'{{fieldName}}',{{/interfaceRelations}}].map(relation => (relations[relation] = false));
+
+    _info.fieldNodes.map(f => {
+      f.selectionSet?.selections.map(s => {
+        if (s.kind === 'InlineFragment') {
+          s.selectionSet.selections.filter(slc => {
+            if (slc.kind === 'Field') {
+              const isN = relations[slc.name.value];
+              if (isN !== undefined) {
+                relations[slc.name.value] = true;
+              }
+            }
+          });
+        }
+      });
+    });
+    return relations;
+  }
+
+  async find<W extends WhereInput>(
+    where?: any,
+    ob?: string | string[],
+    limit?: number,
+    offset?: number,
+    fields?: string[],
+    info?: GraphQLResolveInfo | string
+  ): Promise<{{className}}[]> {
     const _limit = limit || 50;
 		let _offset = offset || 0;
 
@@ -32,6 +62,13 @@ export class {{className}}Service {
 		}
 
     const filteredTypes: string[] = where && where.type_in ? where.type_in : [];
+
+    let requestedRelations: { [key: string]: boolean } = {};
+
+    if (info && typeof info !== 'string') {
+      const _info = info as GraphQLResolveInfo;
+      requestedRelations = this.requestedRelations(_info);
+    }
 
 		{{#subclasses}}
       let  {{camelNamePlural}}: {{className}}[] = [];
@@ -50,9 +87,11 @@ export class {{className}}Service {
 
       {{#interfaceRelations}}
         // relation field is requested
-        {{#subclasses}}
-          {{camelNamePlural}}Query.leftJoin(`{{aliasName}}.{{fieldName}}`, `{{fieldName}}`);
-        {{/subclasses}}
+        if (requestedRelations['{{fieldName}}']) {
+          {{#subclasses}}
+            {{camelNamePlural}}Query.leftJoin(`{{aliasName}}.{{fieldName}}`, `{{fieldName}}`);
+          {{/subclasses}}
+        }
       {{/interfaceRelations}}
       
       if (filteredTypes.length) {

--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -1,14 +1,16 @@
-import { Service } from 'typedi';
-import { getConnection } from 'typeorm';
-import { BaseService, WhereInput } from 'warthog';
+import { Service, Inject } from 'typedi';
+import { getConnection, EntityManager } from 'typeorm';
+import { WhereInput } from 'warthog';
 import { isArray, orderBy } from 'lodash';
 
 {{#subclasses}}
 import { {{className}}Service } from '../{{kebabName}}/{{kebabName}}.service'
 {{/subclasses}}
 
-import { Inject } from 'typedi';
-import _ from 'lodash';
+
+import { {{#subclasses}} {{className}}, {{/subclasses}} } from '../../../model';
+
+
 import { {{className}} } from './{{kebabName}}.model';
 
 @Service('{{className}}Service')
@@ -20,30 +22,40 @@ export class {{className}}Service {
   ) {}
 
   async find<W extends WhereInput>(where?: any, ob?: string | string[], limit?: number, offset?: number, fields?: string[]): Promise<{{className}}[]> {
-    let _limit = limit || 50;
+    const _limit = limit || 50;
 		let _offset = offset || 0;
 
 		if (_limit + _offset > 1000) {
 			throw new Error('Limit or offset are too large');
 		}
 
-		const connection = getConnection();
-		const queryRunner = connection.createQueryRunner();
-		// establish real database connection using our new query runner
-		await queryRunner.connect();
-		await queryRunner.startTransaction('REPEATABLE READ');
-
 		{{#subclasses}}
-      let  {{camelNamePlural}} = [];
+      let  {{camelNamePlural}}: {{className}}[] = [];
     {{/subclasses}}
-		try {
-      // fetching all the fields to allow type-dependent field resolutions
-			{{#subclasses}}
-        {{camelNamePlural}} = await this.{{camelName}}Service.find(where, ob, _limit + _offset, 0);
+
+    await getConnection().transaction(async (manager: EntityManager) => {
+      {{#subclasses}}
+        const {{camelNamePlural}}Query = this.{{camelName}}Service.getQueryBuilder(
+          where,
+          ob,
+          _limit + _offset,
+          0,
+          undefined,
+          { manager }
+        );
       {{/subclasses}}
-		} finally {
-			await queryRunner.commitTransaction();
-		}
+
+      {{#interfaceRelations}}
+        // relation field is requested
+        {{#subclasses}}
+          {{camelNamePlural}}Query.leftJoin(`{{typeormAliasName}}.{{fieldName}}`, `{{fieldName}}`);
+        {{/subclasses}}
+      {{/interfaceRelations}}
+      
+      {{#subclasses}}
+        {{camelNamePlural}} = await {{camelNamePlural}}Query.getMany();
+      {{/subclasses}}
+    })
 
 		let collect: any[] = [{{#subclasses}}...{{camelNamePlural}}, {{/subclasses}}];
 		if (ob) {

--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -51,7 +51,7 @@ export class {{className}}Service {
       {{#interfaceRelations}}
         // relation field is requested
         {{#subclasses}}
-          {{camelNamePlural}}Query.leftJoin(`{{typeormAliasName}}.{{fieldName}}`, `{{fieldName}}`);
+          {{camelNamePlural}}Query.leftJoin(`{{aliasName}}.{{fieldName}}`, `{{fieldName}}`);
         {{/subclasses}}
       {{/interfaceRelations}}
       

--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -61,7 +61,16 @@ export class {{className}}Service {
 			throw new Error('Limit or offset are too large');
 		}
 
-    const filteredTypes: string[] = where && where.type_in ? where.type_in : [];
+    const filteredTypes: string[] = [];
+    if (where) {
+      const { type_in, type_eq } = where;
+      if (type_in) {
+        filteredTypes.push(type_in);
+      }
+      if (type_eq) {
+        filteredTypes.push(type_eq);
+      }
+    }
 
     let requestedRelations: { [key: string]: boolean } = {};
 

--- a/packages/hydra-cli/test/fixtures/interfaces.graphql
+++ b/packages/hydra-cli/test/fixtures/interfaces.graphql
@@ -1,0 +1,17 @@
+type Event @entity {
+  id: ID!
+  inBlock: Int!
+}
+
+interface MembershipEvent @entity {
+  event: Event!
+}
+
+type MembershipBoughtEvent implements MembershipEvent @entity {
+  event: Event!
+  handle: String!
+}
+
+type MembershipInvitedEvent implements MembershipEvent @entity {
+  event: Event!
+}

--- a/packages/hydra-cli/test/helpers/Interfaces.test.ts
+++ b/packages/hydra-cli/test/helpers/Interfaces.test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai'
+import * as fs from 'fs-extra'
+import { WarthogModelBuilder } from '../../src/parse/WarthogModelBuilder'
+import { WarthogModel } from '../../src/model'
+import { ModelRenderer } from '../../src/generate/ModelRenderer'
+
+describe('InterfaceRenderer', () => {
+  let generator: ModelRenderer
+  let warthogModel: WarthogModel
+  let modelTemplate: string
+  let serviceTemplate: string
+
+  before(() => {
+    // set timestamp in the context to make the output predictable
+    modelTemplate = fs.readFileSync(
+      './src/templates/entities/model.ts.mst',
+      'utf-8'
+    )
+    serviceTemplate = fs.readFileSync(
+      './src/templates/interfaces/service.ts.mst',
+      'utf-8'
+    )
+
+    warthogModel = new WarthogModelBuilder(
+      'test/fixtures/interfaces.graphql'
+    ).buildWarthogModel()
+
+    generator = new ModelRenderer(
+      warthogModel,
+      warthogModel.lookupInterface('MembershipEvent')
+    )
+  })
+
+  it('should render interface with enum field', () => {
+    const rendered = generator.render(modelTemplate)
+
+    expect(rendered).include(
+      `@EnumField('MembershipEventTypeOptions', MembershipEventTypeOptions,`,
+      'shoud have an EnumField'
+    )
+  })
+
+  it(`should fetch relations by default`, () => {
+    const rendered = generator.render(serviceTemplate)
+
+    expect(rendered).include(
+      'membershipInvitedEventsQuery.leftJoin(`membershipinvitedevent.event`, `event`)',
+      'should do leftJoin'
+    )
+  })
+
+  it(`should do filtering with enum`, () => {
+    const rendered = generator.render(serviceTemplate)
+
+    expect(rendered).include(
+      `import { MembershipEventTypeOptions } from '../enums/enums'`,
+      'should import auto generated enum'
+    )
+
+    expect(rendered).include(
+      `if (filteredTypes.includes(MembershipEventTypeOptions.MembershipInvitedEvent))`,
+      'should do filtering for implementers'
+    )
+  })
+})

--- a/packages/hydra-e2e-tests/test/e2e/api/graphql-queries.ts
+++ b/packages/hydra-e2e-tests/test/e2e/api/graphql-queries.ts
@@ -94,3 +94,11 @@ export const HOOKS = gql`
     }
   }
 `
+
+export const INTERFACES_FILTERING_BY_ENUM = gql`
+  query InterfaceQuery {
+    events(where: { type_in: [BoughtMemberEvent] }) {
+      indexInBlock
+    }
+  }
+`

--- a/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
+++ b/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
@@ -10,6 +10,7 @@ import {
   LAST_BLOCK_TIMESTAMP,
   INTERFACE_TYPES_WITH_RELATIONSHIP,
   PROCESSOR_SUBSCRIPTION,
+  INTERFACES_FILTERING_BY_ENUM,
 } from './graphql-queries'
 import { SubscriptionClient } from 'graphql-subscriptions-client'
 import pWaitFor = require('p-wait-for')
@@ -144,4 +145,8 @@ export async function queryInterface(): Promise<{ events: [] }> {
   return await getGQLClient().request<{
     events: []
   }>(INTERFACE_TYPES_WITH_RELATIONSHIP)
+}
+
+export async function queryInterfacesByEnum(): Promise<{ events: [] }> {
+  return getGQLClient().request<{ events: [] }>(INTERFACES_FILTERING_BY_ENUM)
 }

--- a/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
+++ b/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
@@ -7,6 +7,7 @@ import {
   findTransfersByValue,
   queryInterface,
   getProcessorStatus,
+  queryInterfacesByEnum,
 } from './api/processor-api'
 import { transfer } from './api/substrate-api'
 import pWaitFor from 'p-wait-for'
@@ -90,5 +91,10 @@ describe('end-to-end transfer tests', () => {
     const { events } = await queryInterface()
     // We don't expect any data only testing Graphql API types
     expect(events.length).to.be.equal(0, 'should not find any event.')
+  })
+
+  it('perform filtering on interfaces by implementers enum types', async () => {
+    const { events } = await queryInterfacesByEnum()
+    expect(events.length).to.be.equal(0, 'shoud be empty event list')
   })
 })


### PR DESCRIPTION
This PR adds support:

- [x] Define interfaces with only relation fields, i.e

```graphql
interface MembershipEvent @entity {
  event: MembershipBoughtEvent
}
```
- [x] Relations are fetched only when they are requested explicitly

- [x]  Filter results by interface implementers

```graphql
type Event @entity {
  id: ID!
  inBlock: Int!
}
interface MembershipEvent @entity {
  event: Event!
}
type MembershipBoughtEvent implements MembershipEvent @entity {
  event: Event!
}
type MemberInvitedEvent implements MembershipEvent @entity {
  event: Event!
}

query {
  membershipEvents(where: {type_in: [ MembershipBoughtEvent, MemberInvitedEvent ]}) {
    ...
  }
}
```