### PR TITLE
fix(hydra-cli): fetch interface relations by default

### DIFF
--- a/packages/hydra-cli/src/generate/ModelRenderer.ts
+++ b/packages/hydra-cli/src/generate/ModelRenderer.ts
@@ -54,6 +54,16 @@ export class ModelRenderer extends AbstractRenderer {
     }
   }
 
+  withInterfaceRelationOptions(): GeneratorContext {
+    if (this.objType.isInterface !== true) {
+      return {}
+    }
+    return {
+      interfaceRelations: utils.interfaceRelations(this.objType),
+      interfaceEnumName: `${this.objType.name}TypeOptions`,
+    }
+  }
+
   withEnums(): GeneratorContext {
     // we need to have a state to render exports only once
     const referncedEnums = new Set<GraphQLEnumType>()
@@ -70,11 +80,10 @@ export class ModelRenderer extends AbstractRenderer {
   }
 
   withFields(): GeneratorContext {
-    const fields: GeneratorContext[] = []
+    const fields: GeneratorContext[] = this.objType.fields.map((f) =>
+      buildFieldContext(f, this.objType)
+    )
 
-    utils
-      .ownFields(this.objType)
-      .map((f) => fields.push(buildFieldContext(f, this.objType)))
     return {
       fields,
     }
@@ -210,6 +219,7 @@ export class ModelRenderer extends AbstractRenderer {
       ...this.withFieldResolvers(),
       ...utils.withNames(this.objType),
       ...this.withVariantNames(),
+      ...this.withInterfaceRelationOptions(),
     }
   }
 }

--- a/packages/hydra-cli/src/generate/field-context.ts
+++ b/packages/hydra-cli/src/generate/field-context.ts
@@ -78,15 +78,22 @@ export function buildFieldContext(
 ): GeneratorContext {
   return {
     ...withFieldTypeGuardProps(f),
-    ...withRequired(f),
-    ...withUnique(f),
     ...withRelation(f),
     ...withArrayCustomFieldConfig(f),
     ...withTsTypeAndDecorator(f),
     ...withDerivedNames(f, entity),
-    ...withDescription(f),
     ...withTransformer(f),
-    ...withArrayProp(f),
+    ...withDecoratorOptions(f),
+  }
+}
+
+export function withDecoratorOptions(f: Field): GeneratorContext {
+  return {
+    required: !f.nullable,
+    description: f.description,
+    unique: f.unique,
+    array: f.isList,
+    apiOnly: f.apiOnly,
   }
 }
 
@@ -100,24 +107,6 @@ export function withFieldTypeGuardProps(f: Field): GeneratorContext {
   ;['mto', 'oto', 'otm', 'mtm'].map((s) => (is[s] = f.relation?.type === s))
   return {
     is: is,
-  }
-}
-
-export function withRequired(f: Field): GeneratorContext {
-  return {
-    required: !f.nullable,
-  }
-}
-
-export function withDescription(f: Field): GeneratorContext {
-  return {
-    description: f.description,
-  }
-}
-
-export function withUnique(f: Field): GeneratorContext {
-  return {
-    unique: f.unique,
   }
 }
 
@@ -179,12 +168,6 @@ export function withImport(f: Field): GeneratorContext {
 export function withRelation(f: Field): GeneratorContext {
   return {
     relation: f.relation,
-  }
-}
-
-export function withArrayProp(f: Field): GeneratorContext {
-  return {
-    array: f.isList,
   }
 }
 

--- a/packages/hydra-cli/src/model/Field.ts
+++ b/packages/hydra-cli/src/model/Field.ts
@@ -33,6 +33,8 @@ export class Field {
 
   derivedFrom?: DerivedFrom
 
+  apiOnly?: boolean
+
   constructor(
     name: string,
     type: string,

--- a/packages/hydra-cli/src/model/ObjectType.ts
+++ b/packages/hydra-cli/src/model/ObjectType.ts
@@ -12,4 +12,5 @@ export interface ObjectType {
   description?: string
   isInterface?: boolean
   interfaces?: ObjectType[] // interface names
+  implementers?: string[] // List of interface implementer names
 }

--- a/packages/hydra-cli/src/model/relations.ts
+++ b/packages/hydra-cli/src/model/relations.ts
@@ -6,6 +6,7 @@ import {
   RelationType,
 } from '.'
 import {
+  camelCase,
   generateJoinColumnName,
   generateJoinTableName,
 } from '../generate/utils'
@@ -77,7 +78,7 @@ function addOne2One(rel: EntityRelationship): void {
 // Typeorm requires to have ManyToOne field on the related object if the relation is OneToMany
 function createAdditionalField(entity: ObjectType, field: Field): Field {
   const f = new Field(
-    entity.name.toLowerCase() + field.name,
+    camelCase(entity.name.toLowerCase() + field.name),
     entity.name,
     true,
     false,

--- a/packages/hydra-cli/src/templates/entities/model.ts.mst
+++ b/packages/hydra-cli/src/templates/entities/model.ts.mst
@@ -52,8 +52,7 @@ import { InterfaceType } from 'type-graphql';
 {{#isInterface}}
 @InterfaceType({{#description}} { description: `{{{description}}}` } {{/description}})
 {{/isInterface}}
-export {{#isInterface}}abstract{{/isInterface}} class {{className}} 
-  extends {{^interfaces}}BaseModel{{/interfaces}} {{#interfaces}} {{className}} {{/interfaces}} {
+export class {{className}} {{^isInterface}}extends BaseModel{{/isInterface}} {
 
 {{#fields}}
   {{#is.otm}}
@@ -144,7 +143,8 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
   {{#is.enum}}
     @EnumField('{{tsType}}', {{tsType}}, { 
       {{^required}}nullable: true,{{/required}} 
-      {{#description}}description: `{{{description}}}`{{/description}} })
+      {{#description}}description: `{{{description}}}`{{/description}}
+      {{#apiOnly}}, apiOnly: true {{/apiOnly}} })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}:{{tsType}} 
   {{/is.enum}}
 
@@ -160,10 +160,10 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
 
 {{/fields}}
 
-{{^interfaces}}
+{{^isInterface}}
   constructor(init?: Partial<{{className}}>) {
 		super();
 		Object.assign(this, init);
 	}
-{{/interfaces}}
+{{/isInterface}}
 }

--- a/packages/hydra-cli/src/templates/graphql-server/src/WarthogBaseService.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/WarthogBaseService.ts.mst
@@ -16,7 +16,8 @@ export class WarthogBaseService<E extends BaseModel> extends BaseService<E> {
     orderBy?: string | string[],
     pageOptions?: LimitOffset,
     fields?: string[],
-    paramKeyPrefix: string = 'param'
+    paramKeyPrefix: string = 'param',
+    aliases: (field: string) => string | undefined = () => undefined
   ): SelectQueryBuilder<E> {
     const DEFAULT_LIMIT = 50;
     let qb = this.manager.createQueryBuilder<E>(this.entityClass, this.klass);
@@ -39,24 +40,13 @@ export class WarthogBaseService<E extends BaseModel> extends BaseService<E> {
       }
       // Querybuilder requires you to prefix all fields with the table alias.  It also requires you to
       // specify the field name using it's TypeORM attribute name, not the camel-cased DB column name
-      const selection = fields.map((field) => `${this.klass}.${field}`);
-      qb = qb.select(selection);
+      qb = qb.select(`${this.klass}.id`, aliases('id'));
+      fields.forEach(
+        (field) => field !== 'id' && qb.addSelect(`${this.klass}.${field}`, aliases(field))
+      );
     }
 
-    if (orderBy) {
-      if (!Array.isArray(orderBy)) {
-        orderBy = [orderBy];
-      }
-
-      orderBy.forEach((orderByItem: string) => {
-        const parts = orderByItem.toString().split('_');
-        // TODO: ensure attr is one of the properties on the model
-        const attr = parts[0];
-        const direction: 'ASC' | 'DESC' = parts[1] as 'ASC' | 'DESC';
-
-        qb = qb.addOrderBy(this.attrToDBColumn(attr), direction);
-      });
-    }
+    qb = addOrderBy(orderBy, qb, (attr) => this.attrToDBColumn(attr));
 
     // Soft-deletes are filtered out by default, setting `deletedAt_all` is the only way to turn this off
     const hasDeletedAts = Object.keys(where).find((key) => key.indexOf('deletedAt_') === 0);
@@ -168,4 +158,54 @@ export class WarthogBaseService<E extends BaseModel> extends BaseService<E> {
 
     return qb;
   }
+}
+
+export function addOrderBy<T>(
+  orderBy: string | string[] | undefined,
+  qb: SelectQueryBuilder<T>,
+  attrToDBColumn: (attr: string) => string
+): SelectQueryBuilder<T> {
+  const [attrs, directions] = parseOrderBy(orderBy);
+
+  if (attrs.length !== directions.length) {
+    throw new Error('Number of attributes and sorting directions must match');
+  }
+
+  attrs.forEach((attr: string, index: number) => {
+    qb = qb.addOrderBy(attrToDBColumn(attr), directions[index].toUpperCase() as 'ASC' | 'DESC');
+  });
+  return qb;
+}
+
+export function parseOrderBy(
+  orderBy: string | string[] | undefined
+): [string[], ('asc' | 'desc')[]] {
+  const attrs: string[] = [];
+  const directions: ('asc' | 'desc')[] = [];
+  if (orderBy) {
+    if (!Array.isArray(orderBy)) {
+      orderBy = [orderBy];
+    }
+
+    orderBy.forEach((orderByItem: string) => {
+      const parts = orderByItem.toString().split('_');
+      // TODO: ensure attr is one of the properties on the model
+      const attr = parts[0];
+      const direction: 'asc' | 'desc' = parts[1].toLowerCase() as 'asc' | 'desc';
+
+      attrs.push(attr);
+      directions.push(direction);
+    });
+  }
+  return [attrs, directions];
+}
+
+export function orderByFields(orderBy: string | string[] | undefined): string[] {
+  if (orderBy === undefined) {
+    return [];
+  }
+  if (!Array.isArray(orderBy)) {
+    orderBy = [(orderBy as unknown) as string];
+  }
+  return orderBy.map((o) => o.toString().split('_')[0]);
 }

--- a/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
@@ -22,7 +22,7 @@ class CustomNamingStrategy extends SnakeNamingStrategy {
 async function bootstrap() {
   loadConfig();
 
-  const server = getServer({}, { namingStrategy: new CustomNamingStrategy(), maxQueryExecutionTime: 1000, logging: ["error"] });
+  const server = getServer({}, { namingStrategy: new CustomNamingStrategy(), maxQueryExecutionTime: 1000, logging: [ process.env.WARTHOG_DB_LOGGING || "error"] });
 
   // Create database tables. Warthog migrate command does not support CustomNamingStrategy thats why
   // we have this code

--- a/packages/hydra-cli/src/templates/interfaces/resolver.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/resolver.ts.mst
@@ -1,6 +1,7 @@
-import { Arg, Args, Mutation, Query, Resolver } from 'type-graphql';
+import { Arg, Args, Mutation, Query, Resolver, Info } from 'type-graphql';
 import { Inject } from 'typedi';
 import { Fields, StandardDeleteResponse, UserId } from 'warthog';
+import { GraphQLResolveInfo } from 'graphql';
 
 import {
   {{className}}CreateInput,
@@ -21,9 +22,10 @@ export class {{className}}Resolver {
   @Query(() => [{{className}}])
   async {{camelNamePlural}}(
     @Args() { where, orderBy, limit, offset }: {{className}}WhereArgs,
-    @Fields() fields: string[]
+    @Fields() fields: string[],
+    @Info() info?: GraphQLResolveInfo | string
   ): Promise<{{className}}[]> {
-    return this.service.find<{{className}}WhereInput>(where, orderBy, limit, offset, fields);
+    return this.service.find<{{className}}WhereInput>(where, orderBy, limit, offset, fields, info);
   }
 
   

--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -1,70 +1,126 @@
-import { Service } from 'typedi';
-import { getConnection } from 'typeorm';
-import { BaseService, WhereInput } from 'warthog';
-import { isArray, orderBy } from 'lodash';
+import { Service, Inject } from 'typedi';
+import { getManager, SelectQueryBuilder, ObjectLiteral } from 'typeorm';
+import { BaseModel, WhereInput } from 'warthog';
+import { snakeCase, camelCase, uniq, orderBy } from 'lodash';
+import { GraphQLResolveInfo } from 'graphql';
 
 {{#subclasses}}
 import { {{className}}Service } from '../{{kebabName}}/{{kebabName}}.service'
+import { {{className}} } from '../{{kebabName}}/{{kebabName}}.model';
 {{/subclasses}}
 
-import { Inject } from 'typedi';
-import _ from 'lodash';
 import { {{className}} } from './{{kebabName}}.model';
+
+import { {{className}}TypeOptions } from '../enums/enums';
+
+import {
+  WarthogBaseService,
+  addOrderBy,
+  orderByFields,
+  parseOrderBy,
+} from '../../WarthogBaseService';
 
 @Service('{{className}}Service')
 export class {{className}}Service {
+  public readonly typeToService: { [key: string]: WarthogBaseService<any> } = {};
+
   constructor(
     {{#subclasses}}
      @Inject('{{className}}Service') public readonly {{camelName}}Service: {{className}}Service,
     {{/subclasses}}
-  ) {}
-
-  async find<W extends WhereInput>(where?: any, ob?: string | string[], limit?: number, offset?: number, fields?: string[]): Promise<{{className}}[]> {
-    let _limit = limit || 50;
-		let _offset = offset || 0;
-
-		if (_limit + _offset > 1000) {
-			throw new Error('Limit or offset are too large');
-		}
-
-		const connection = getConnection();
-		const queryRunner = connection.createQueryRunner();
-		// establish real database connection using our new query runner
-		await queryRunner.connect();
-		await queryRunner.startTransaction('REPEATABLE READ');
-
-		{{#subclasses}}
-      let  {{camelNamePlural}} = [];
+  ) {
+    {{#subclasses}}  
+    this.typeToService['{{className}}'] = {{camelName}}Service;
     {{/subclasses}}
-		try {
-      // fetching all the fields to allow type-dependent field resolutions
-			{{#subclasses}}
-        {{camelNamePlural}} = await this.{{camelName}}Service.find(where, ob, _limit + _offset, 0);
-      {{/subclasses}}
-		} finally {
-			await queryRunner.commitTransaction();
-		}
+  }
 
-		let collect: any[] = [{{#subclasses}}...{{camelNamePlural}}, {{/subclasses}}];
-		if (ob) {
-      const directions: ('asc' | 'desc')[] = []
-      const attrs: string[] = []
-      if (!isArray(ob)) {
-        ob = [ob]
-      }
-      ob.map(o => {
-			// NB: copied from warthog's BaseService
-        const parts = o.toString().split('_');
-        const direction: 'asc' | 'desc' = parts[1] as 'asc' | 'desc';
-        directions.push(direction)
-        attrs.push(parts[0])
-      })
-			collect = orderBy(collect, attrs, directions);
-		}
+  async find<W extends WhereInput>(
+    where?: any,
+    ob?: string | string[],
+    _limit?: number,
+    _offset?: number,
+    _fields?: string[],
+    info?: GraphQLResolveInfo | string
+  ): Promise<Event[]> {
+    const limit = _limit ?? 50;
+    const offset = _offset ?? 0;
+    const fields = uniq([...(_fields || []), ...orderByFields(ob)]);
 
-		const _end = Math.min(collect.length, _limit + _offset);
-		_offset = Math.min(collect.length, _offset);
+    if (limit > 10000) {
+      throw new Error('Cannot fetch more than 10000 at a time');
+    }
 
-		return collect.slice(_offset, _end);
+    const { type_in, type_eq } = where;
+    const types: string[] = (type_eq
+      ? [type_eq]
+      : type_in || [ {{#subclasses}}  {{className}}, {{/subclasses}} ]
+    ).map((t: EventTypeOptions) => t.toString());
+
+    delete where.type_in;
+    delete where.type_eq;
+    // take fields that are present in all implemetations
+    const commonFields = fields.filter((f) =>
+      types.reduce(
+        (hasField: boolean, t) => this.typeToService[t].columnMap[f] !== undefined && hasField,
+        true
+      )
+    );
+
+    const queries: SelectQueryBuilder<unknown>[] = types.map(
+      (t) =>
+        (this.typeToService[t]
+          .buildFindQueryWithParams(
+            <any>where,
+            undefined,
+            undefined,
+            commonFields,
+            camelCase(t),
+            (field) => snakeCase(field)
+          )
+          .addSelect(`'${t}'`, 'type')
+          .take(undefined) as unknown) as SelectQueryBuilder<unknown>
+    );
+
+    const parameters = queries.reduce((params: ObjectLiteral, q: SelectQueryBuilder<any>) => {
+      return { ...params, ...q.getParameters() };
+    }, {} as ObjectLiteral);
+
+    let rawQuery = queries.map((q) => `(  ${q.getQuery()} )`).join(' UNION ALL ');
+
+    let qb = getManager()
+      .createQueryBuilder()
+      .select('u.id', 'u_id')
+      .addSelect('u.type', 'u_type')
+      .from(`( ${rawQuery} )`, 'u')
+      .setParameters(parameters)
+      .take(limit)
+      .skip(offset);
+
+    qb = (addOrderBy(
+      ob,
+      <any>qb,
+      (attr) => `u.${snakeCase(attr)}`
+    ) as unknown) as SelectQueryBuilder<unknown>;
+
+    const results = await qb.getRawMany<{ u_id: string; u_type: string }>();
+
+    const entityPromises: Promise<Event[]>[] = types.map((t) => {
+      const service = this.typeToService[t];
+      return service.find(
+        { id_in: results.filter((r) => r.u_type === t).map((r) => r.u_id) },
+        undefined,
+        limit,
+        undefined,
+        fields.filter((f) => service.columnMap[f] !== undefined)
+      );
+    });
+
+    const result = (await Promise.all<Event[]>(entityPromises)).reduce(
+      (acc, curr) => [...acc, ...curr],
+      [] as Event[]
+    );
+    const [attrs, dirs] = parseOrderBy(ob);
+
+    return orderBy(result, attrs, dirs);
   }
 }

--- a/packages/hydra-cli/test/fixtures/interfaces.graphql
+++ b/packages/hydra-cli/test/fixtures/interfaces.graphql
@@ -1,0 +1,17 @@
+type Event @entity {
+  id: ID!
+  inBlock: Int!
+}
+
+interface MembershipEvent @entity {
+  event: Event!
+}
+
+type MembershipBoughtEvent implements MembershipEvent @entity {
+  event: Event!
+  handle: String!
+}
+
+type MembershipInvitedEvent implements MembershipEvent @entity {
+  event: Event!
+}

--- a/packages/hydra-cli/test/helpers/Interfaces.test.ts
+++ b/packages/hydra-cli/test/helpers/Interfaces.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai'
+import * as fs from 'fs-extra'
+import { WarthogModelBuilder } from '../../src/parse/WarthogModelBuilder'
+import { WarthogModel } from '../../src/model'
+import { ModelRenderer } from '../../src/generate/ModelRenderer'
+
+describe('InterfaceRenderer', () => {
+  let generator: ModelRenderer
+  let warthogModel: WarthogModel
+  let modelTemplate: string
+
+  before(() => {
+    // set timestamp in the context to make the output predictable
+    modelTemplate = fs.readFileSync(
+      './src/templates/entities/model.ts.mst',
+      'utf-8'
+    )
+
+    warthogModel = new WarthogModelBuilder(
+      'test/fixtures/interfaces.graphql'
+    ).buildWarthogModel()
+
+    generator = new ModelRenderer(
+      warthogModel,
+      warthogModel.lookupInterface('MembershipEvent')
+    )
+  })
+
+  it('should render interface with enum field', () => {
+    const rendered = generator.render(modelTemplate)
+
+    expect(rendered).include(
+      `@EnumField('MembershipEventTypeOptions', MembershipEventTypeOptions,`,
+      'shoud have an EnumField'
+    )
+  })
+})

--- a/packages/hydra-cli/test/helpers/ModelRenderer.test.ts
+++ b/packages/hydra-cli/test/helpers/ModelRenderer.test.ts
@@ -346,7 +346,7 @@ describe('ModelRenderer', () => {
     )
   })
 
-  it('should extend interface type', function () {
+  it('Should render all fields in the interface implementations', () => {
     const model = fromStringSchema(`
         interface IEntity @entity {
             field1: String
@@ -354,15 +354,30 @@ describe('ModelRenderer', () => {
         type A implements IEntity @entity {
             field1: String
             field2: String
-    }`)
+        }`)
     generator = new ModelRenderer(model, model.lookupEntity('A'))
     const rendered = generator.render(modelTemplate)
-    expect(rendered).to.include('extends IEntity')
-    expect(rendered).to.include(
-      `import { IEntity } from '../i-entity/i-entity.model'`,
-      'should import interface type'
-    )
+    expect(rendered).to.include('field1', 'should render both fields')
+    expect(rendered).to.include('field2', 'should render both fields')
   })
+  // THIS IS NO LONGER THE CASE
+  // it('should extend interface type', function () {
+  //   const model = fromStringSchema(`
+  //       interface IEntity @entity {
+  //           field1: String
+  //       }
+  //       type A implements IEntity @entity {
+  //           field1: String
+  //           field2: String
+  //   }`)
+  //   generator = new ModelRenderer(model, model.lookupEntity('A'))
+  //   const rendered = generator.render(modelTemplate)
+  //   expect(rendered).to.include('extends IEntity')
+  //   expect(rendered).to.include(
+  //     `import { IEntity } from '../i-entity/i-entity.model'`,
+  //     'should import interface type'
+  //   )
+  // })
 
   it('should import two unions from variants', async function () {
     const model = fromStringSchema(`
@@ -401,19 +416,20 @@ describe('ModelRenderer', () => {
     )
   })
 
-  it('should not include interface field', function () {
-    const model = fromStringSchema(`
-        interface IEntity @entity {
-            field1: String
-        }
-        type A implements IEntity @entity {
-            field1: String
-            field2: String
-    }`)
-    generator = new ModelRenderer(model, model.lookupEntity('A'))
-    const rendered = generator.render(modelTemplate)
-    expect(rendered).to.not.include('field1')
-  })
+  // TODO: THIS TEST DOES NOT APPLY, we render all the interface fields
+  // it('should not include interface field', function () {
+  //   const model = fromStringSchema(`
+  //       interface IEntity @entity {
+  //           field1: String
+  //       }
+  //       type A implements IEntity @entity {
+  //           field1: String
+  //           field2: String
+  //   }`)
+  //   generator = new ModelRenderer(model, model.lookupEntity('A'))
+  //   const rendered = generator.render(modelTemplate)
+  //   expect(rendered).to.not.include('field1')
+  // })
 
   it('should render interface', function () {
     const model = fromStringSchema(`

--- a/packages/hydra-cli/test/helpers/WarthogModel.test.ts
+++ b/packages/hydra-cli/test/helpers/WarthogModel.test.ts
@@ -109,6 +109,18 @@ describe('WarthogModel', () => {
     )
   })
 
+  it('Should add all fields to interface implementations', () => {
+    const model = fromStringSchema(`
+        interface IEntity @entity {
+            field1: String
+        }
+        type A implements IEntity @entity {
+            field1: String
+            field2: String
+        }`)
+    expect(model.lookupEntity('A').fields).length(2, 'Should add both fields')
+  })
+
   it('Should lookup types', () => {
     const model = fromStringSchema(`
     union Poor = HappyPoor | Miserable

--- a/packages/hydra-cli/test/helpers/model-index-context.test.ts
+++ b/packages/hydra-cli/test/helpers/model-index-context.test.ts
@@ -62,7 +62,7 @@ describe('model index render', () => {
       'should import entities'
     )
     expect(c(rendered)).to.include(
-      c(`export { MyEntity } `),
+      c(`export { MyEntity }`),
       'should export entities'
     )
     expect(c(rendered)).to.include(
@@ -72,7 +72,7 @@ describe('model index render', () => {
       'should import interfaces'
     )
     expect(c(rendered)).to.include(
-      c(`export { MyInterface } `),
+      c(`export { MyInterface }`),
       'should export interfaces'
     )
   })

--- a/packages/hydra-e2e-tests/fixtures/manifest.yml
+++ b/packages/hydra-e2e-tests/fixtures/manifest.yml
@@ -29,6 +29,9 @@ mappings:
     - handler: preHook
       filter:
         height: '[0,0]'
+    - handler: loader
+      filter:
+        height: '[0,0]'
     - handler: preHook
       filter: 
         height: '[1, 2]'

--- a/packages/hydra-e2e-tests/fixtures/mappings/index.ts
+++ b/packages/hydra-e2e-tests/fixtures/mappings/index.ts
@@ -2,3 +2,5 @@
 // so that the indexer picks them up
 // export { balancesTransfer as balances_Transfer } from './transfer'
 export { balancesTransfer, timestampCall, preHook, postHook } from './mappings'
+
+export { loader } from './loaders'

--- a/packages/hydra-e2e-tests/fixtures/mappings/loaders.ts
+++ b/packages/hydra-e2e-tests/fixtures/mappings/loaders.ts
@@ -1,0 +1,46 @@
+import {
+  Event,
+  EventA,
+  EventB,
+  EventC,
+  Network,
+} from '../generated/graphql-server/model'
+
+// run 'NODE_URL=<RPC_ENDPOINT> EVENTS=<comma separated list of events> yarn codegen:mappings-types'
+// to genenerate typescript classes for events, such as Balances.TransferEvent
+import { BlockContext, StoreContext } from '@dzlzv/hydra-common'
+
+// run before genesis
+export async function loader({ store }: BlockContext & StoreContext) {
+  console.log(`Loading events`)
+  const a = new EventA({
+    inExtrinsic: 'test',
+    inBlock: 0,
+    network: Network.ALEXANDRIA,
+    indexInBlock: 0,
+    field1: 'field1',
+  })
+
+  const b = new EventB({
+    inExtrinsic: 'test',
+    inBlock: 0,
+    network: Network.BABYLON,
+    indexInBlock: 1,
+    field2: 'field2',
+  })
+
+  const c = new EventC({
+    inExtrinsic: 'test',
+    inBlock: 0,
+    network: Network.OLYMPIA,
+    indexInBlock: 2,
+    field3: 'field3',
+  })
+
+  await Promise.all([
+    store.save<EventA>(a),
+    store.save<EventB>(b),
+    store.save<EventC>(c),
+  ])
+  console.log(`Loaded events`)
+}

--- a/packages/hydra-e2e-tests/fixtures/schema.graphql
+++ b/packages/hydra-e2e-tests/fixtures/schema.graphql
@@ -57,19 +57,49 @@ type MiddleClass @variant {
 
 union Status = MiddleClass | HappyPoor | Miserable
 
-############## Test purpose only @hydra-e2e-tests #################
-# To make sure graphql api is generated as expected
+
 type Extrinsic @entity {
   id: ID!
   hash: String!
 }
+
 interface Event @entity {
   indexInBlock: Int!
-  inExtrinsic: Extrinsic
+  inExtrinsic: String
+  inBlock: Int!
+  network: Network!
 }
-type BoughtMemberEvent implements Event @entity {
+
+type EventA implements Event @entity { 
   id: ID!
+  inExtrinsic: String
+  inBlock: Int!
+  network: Network!
   indexInBlock: Int!
-  inExtrinsic: Extrinsic
+  field1: String!
 }
-###################################################
+
+type EventB implements Event @entity { 
+  id: ID!
+  inExtrinsic: String
+  inBlock: Int!
+  network: Network!
+  indexInBlock: Int!
+  field2: String!
+}
+
+type EventC implements Event @entity {
+  id: ID!
+  inExtrinsic: String
+  inBlock: Int!
+  network: Network!
+  indexInBlock: Int!  
+  field3: String!
+}
+
+enum Network {
+  BABYLON
+  ALEXANDRIA
+  ROME
+  OLYMPIA
+}

--- a/packages/hydra-e2e-tests/run-tests.sh
+++ b/packages/hydra-e2e-tests/run-tests.sh
@@ -26,7 +26,7 @@ docker-compose up -d
 
 # wait for the processor to start grinding 
 attempt_counter=0
-max_attempts=20
+max_attempts=25
 
 until $(curl -s --head  --request GET http://localhost:3000/metrics/hydra_processor_last_scanned_block | grep "200" > /dev/null);  do
     if [ ${attempt_counter} -eq ${max_attempts} ];then

--- a/packages/hydra-e2e-tests/test/e2e/api/graphql-queries.ts
+++ b/packages/hydra-e2e-tests/test/e2e/api/graphql-queries.ts
@@ -85,19 +85,19 @@ query {
 }
 `
 
-export const INTERFACE_TYPES_WITH_RELATIONSHIP = gql`
-  query InterfaceQuery {
-    events {
-      indexInBlock
-      ... on BoughtMemberEvent {
-        inExtrinsic {
-          id
-          hash
-        }
-      }
-    }
-  }
-`
+// export const INTERFACE_TYPES_WITH_RELATIONSHIP = gql`
+//   query InterfaceQuery {
+//     events {
+//       indexInBlock
+//       ... on BoughtMemberEvent {
+//         inExtrinsic {
+//           id
+//           hash
+//         }
+//       }
+//     }
+//   }
+// `
 
 export const PROCESSOR_SUBSCRIPTION = gql`
   subscription {
@@ -138,6 +138,36 @@ export const VARIANT_FILTER_MISREABLE_ACCOUNTS = gql`
           hates
         }
       }
+    }
+  }
+`
+
+export const EVENT_INTERFACE_QUERY = gql`
+  query {
+    events(
+      where: { inBlock_lt: 2, type_in: [EventA, EventB, EventC] }
+      orderBy: [indexInBlock_DESC, network_DESC]
+    ) {
+      indexInBlock
+      inExtrinsic
+      network
+      ... on EventA {
+        field1
+      }
+      ... on EventB {
+        field2
+      }
+      ... on EventC {
+        field3
+      }
+    }
+  }
+`
+
+export const INTERFACES_FILTERING_BY_ENUM = gql`
+  query InterfaceQuery {
+    events(where: { type_in: [EventA] }) {
+      indexInBlock
     }
   }
 `

--- a/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
+++ b/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
@@ -8,8 +8,8 @@ import {
   FETCH_INSERTED_AT_FIELD_FROM_TRANSFER,
   FTS_COMMENT_QUERY_WITH_WHERE_CONDITION,
   LAST_BLOCK_TIMESTAMP,
-  INTERFACE_TYPES_WITH_RELATIONSHIP,
   PROCESSOR_SUBSCRIPTION,
+  INTERFACES_FILTERING_BY_ENUM,
 } from './graphql-queries'
 import { SubscriptionClient } from 'graphql-subscriptions-client'
 import pWaitFor = require('p-wait-for')
@@ -140,10 +140,8 @@ export async function getProcessorStatus(): Promise<ProcessorStatus> {
   return processorStatus as ProcessorStatus
 }
 
-export async function queryInterface(): Promise<{ events: [] }> {
-  return await getGQLClient().request<{
-    events: []
-  }>(INTERFACE_TYPES_WITH_RELATIONSHIP)
+export async function queryInterfacesByEnum(): Promise<{ events: [] }> {
+  return getGQLClient().request<{ events: [] }>(INTERFACES_FILTERING_BY_ENUM)
 }
 
 export async function accountByOutgoingTxValue(

--- a/packages/hydra-e2e-tests/test/e2e/interfaces-e2e.test.ts
+++ b/packages/hydra-e2e-tests/test/e2e/interfaces-e2e.test.ts
@@ -1,0 +1,45 @@
+import pWaitFor from 'p-wait-for'
+import { expect } from 'chai'
+import {
+  getGQLClient,
+  getProcessorStatus,
+  queryInterfacesByEnum,
+} from './api/processor-api'
+import { EVENT_INTERFACE_QUERY } from './api/graphql-queries'
+
+describe('end-to-end interfaces tests', () => {
+  before(async () => {
+    // wait until the indexer indexes the block and the processor picks it up
+    await pWaitFor(
+      async () => {
+        return (await getProcessorStatus()).lastCompleteBlock > 0
+      },
+      { interval: 50 }
+    )
+  })
+
+  it('executes a flat interface query with fragments', async () => {
+    const result = await getGQLClient().request<{
+      events: any[]
+    }>(EVENT_INTERFACE_QUERY)
+
+    expect(result.events.length).to.be.equal(3, 'should find three events')
+    expect(result.events[0].field3).to.be.equal(
+      'field3',
+      'should return eventC with field3'
+    )
+    expect(result.events[1].field2).to.be.equal(
+      'field2',
+      'should return eventB with field2'
+    )
+    expect(result.events[2].field1).to.be.equal(
+      'field1',
+      'should return eventA with field1'
+    )
+  })
+
+  it('perform filtering on interfaces by implementers enum types', async () => {
+    const { events } = await queryInterfacesByEnum()
+    expect(events.length).to.be.equal(1, 'shoud find an interface by type')
+  })
+})

--- a/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
+++ b/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
@@ -5,7 +5,6 @@ import {
   findTransfersByComment,
   findTransfersByCommentAndWhereCondition,
   findTransfersByValue,
-  queryInterface,
   getProcessorStatus,
   accountByOutgoingTxValue,
   getGQLClient,
@@ -104,10 +103,47 @@ describe('end-to-end transfer tests', () => {
     )
   })
 
-  it('performs query on interface types, expect implementer to hold relationship', async () => {
-    const { events } = await queryInterface()
-    // We don't expect any data only testing Graphql API types
-    expect(events.length).to.be.equal(0, 'should not find any event.')
+  it('founds an account by incoming tx value (some)', async () => {
+    let accs = await accountByOutgoingTxValue(
+      ACCOUNTS_BY_VALUE_GT_SOME,
+      BigInt(300000)
+    )
+    expect(accs.length).to.be.equal(0, 'some tx vals > 300000: false')
+
+    accs = await accountByOutgoingTxValue(
+      ACCOUNTS_BY_VALUE_GT_SOME,
+      BigInt(200000)
+    )
+    expect(accs.length).to.be.equal(1, 'some tx vals > 200000: true')
+  })
+
+  it('founds an account by incoming tx value (none)', async () => {
+    let accs = await accountByOutgoingTxValue(
+      ACCOUNTS_BY_VALUE_GT_NONE,
+      BigInt(300000)
+    )
+    expect(accs.length).to.be.equal(2, 'none tx vals > 300000: true') // BOTH BOB AND ALICE
+
+    accs = await accountByOutgoingTxValue(
+      ACCOUNTS_BY_VALUE_GT_NONE,
+      BigInt(200000)
+    )
+    expect(accs.length).to.be.equal(1, 'none tx vals > 200000: false') // ONLY BOB, it has no outgoing txs
+  })
+
+  it('founds an account by incoming tx value (every)', async () => {
+    let accs = await accountByOutgoingTxValue(
+      ACCOUNTS_BY_VALUE_GT_EVERY,
+      BigInt(txAmount2) // since the value filter is gt,
+      // the second transfer does not satisfy the condition
+    )
+    expect(accs.length).to.be.equal(0, 'every tx val > 1000: false')
+
+    accs = await accountByOutgoingTxValue(
+      ACCOUNTS_BY_VALUE_GT_EVERY,
+      BigInt(20)
+    )
+    expect(accs.length).to.be.equal(1, 'every tx val > 20: true')
   })
 
   it('founds an account by incoming tx value (some)', async () => {


### PR DESCRIPTION
affects: @dzlzv/hydra-cli

A fully reworked implementation of the interfaces service with minimal dependency on the code
generation. First, IDs are fetched from a union of each implementation table satisfying the filter,
and afterwards each table is queried separately by those IDs.

fix(hydra-cli): add TYPEORM_LOGGING option to the graphql-server

affects: @dzlzv/hydra-cli

test(hydra-e2e-test): add e2e tests for interface queries

affects: hydra-e2e-tests