### PR TITLE
fix(hydra-processor): set createdAt, updatedAt to the block timestamp

### DIFF
--- a/packages/hydra-e2e-tests/test/e2e/api/graphql-queries.ts
+++ b/packages/hydra-e2e-tests/test/e2e/api/graphql-queries.ts
@@ -70,6 +70,9 @@ export const FETCH_INSERTED_AT_FIELD_FROM_TRANSFER = gql`
   query {
     transfers(limit: 1) {
       insertedAt
+      createdAt
+      updatedAt
+      timestamp
     }
   }
 `

--- a/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
+++ b/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
@@ -67,14 +67,22 @@ export async function findTransfersByValue(
   return result.transfers
 }
 
-export async function fetchDateTimeFieldFromTransfer(): Promise<Date> {
+export async function fetchDateTimeFieldFromTransfer(): Promise<{
+  insertedAt: string
+  updatedAt: string
+  createdAt: string
+  timestamp: string
+}> {
   const result = await getGQLClient().request<{
     transfers: {
       insertedAt: string
+      updatedAt: string
+      createdAt: string
+      timestamp: string
     }[]
   }>(FETCH_INSERTED_AT_FIELD_FROM_TRANSFER)
 
-  return new Date(result.transfers[0].insertedAt)
+  return result.transfers[0]
 }
 
 export async function findTransfersByCommentAndWhereCondition(

--- a/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
+++ b/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
@@ -80,8 +80,28 @@ describe('end-to-end transfer tests', () => {
   })
 
   it('fetch datetime field from transfer', async () => {
-    const date = await fetchDateTimeFieldFromTransfer()
-    expect(date.getTime()).to.be.lessThan(Date.now())
+    const {
+      insertedAt,
+      createdAt,
+      updatedAt,
+      timestamp,
+    } = await fetchDateTimeFieldFromTransfer()
+    const ts = Number.parseInt(timestamp)
+
+    console.log(`Timestamp: ${timestamp}, ts: ${ts}`)
+
+    expect(new Date(updatedAt).getTime()).to.be.equal(
+      new Date(ts).getTime(),
+      'should set updatedAt'
+    )
+    expect(new Date(createdAt).getTime()).to.be.equal(
+      new Date(ts).getTime(),
+      'should set createdAt'
+    )
+    expect(new Date(insertedAt).getTime()).to.be.equal(
+      new Date(ts).getTime(),
+      'should set insertedAt'
+    )
   })
 
   it('performs full-text-search with filtering options with no result', async () => {


### PR DESCRIPTION
… by default

affects: hydra-e2e-tests, @joystream/hydra-processor

ISSUES CLOSED: #400