### PR TITLE
Command for building all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,17 @@
     ]
   },
   "scripts": {
-    "e2e-test": "yarn workspace hydra-e2e-tests run e2e-test",
+    "build": "yarn build:common && yarn build:utils && yarn build:bn-typeorm && yarn build:typegen && yarn build:processor && yarn build:indexer && yarn build:indexer-gateway && yarn build:cli && yarn build:e2e-test",
+    "build:common": "yarn workspace @joystream/hydra-common build",
+    "build:utils": "yarn workspace @joystream/hydra-db-utils build",
+    "build:bn-typeorm": "yarn workspace @joystream/bn-typeorm build",
+    "build:typegen": "yarn workspace @joystream/hydra-typegen build",
+    "build:processor": "yarn workspace @joystream/hydra-processor build",
+    "build:indexer": "yarn workspace @joystream/hydra-indexer build",
+    "build:indexer-gateway": "yarn workspace @joystream/hydra-indexer-gateway build",
+    "build:cli": "yarn workspace @joystream/hydra-cli build",
+    "build:e2e-test": "yarn workspace @joystream/hydra-e2e-tests build",
+    "e2e-test": "yarn workspace @joystream/hydra-e2e-tests run e2e-test",
     "lint": "yarn workspaces run lint",
     "postinstall": "is-ci || husky install"
   },

--- a/packages/hydra-e2e-tests/package.json
+++ b/packages/hydra-e2e-tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hydra-e2e-tests",
+  "name": "@joystream/hydra-e2e-tests",
   "version": "3.1.0-alpha.3",
   "private": "true",
   "description": "End-to-end tests for Hydra services",


### PR DESCRIPTION
There was an issue when running the following commands after freshly pulling repository resulted in error:
```
yarn
yarn workspace @joystream/hydra-processor build
yarn workspace @joystream/hydra-processor test # this will cause error because dependency - hydra-common is not built
```
The same was happening when running e2e tests, etc. because dependencies like `hydra-common` and `hydra-db-utils` are not built at that moment.


This PR adds a command to build all repositories - `yarn build`. It also renames `hydra-e2e-tests` -> `@joystream/hydra-e2e-tests`  to be consistent with other repo names.