### PR TITLE
Update warthog version 2.35.0->2.36.0

### DIFF
--- a/packages/hydra-cli/package.json
+++ b/packages/hydra-cli/package.json
@@ -48,7 +48,7 @@
     "@inquirer/input": "^0.0.13-alpha.0",
     "@inquirer/password": "^0.0.12-alpha.0",
     "@inquirer/select": "^0.0.13-alpha.0",
-    "@joystream/warthog": "^2.35.0",
+    "@joystream/warthog": "^2.36.0",
     "@oclif/command": "^1.5.20",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
@@ -80,7 +80,7 @@
     "lodash": "^4.17.20",
     "pg": "^8.3.2",
     "pg-listen": "^1.7.0",
-    "@joystream/warthog": "^2.35.0",
+    "@joystream/warthog": "^2.36.0",
     "typeorm": "^0.2.31"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,10 +1007,10 @@
   resolved "https://registry.yarnpkg.com/@joystream/prettier-config/-/prettier-config-1.0.0.tgz#d87c6370244f39281d9052c619977ca60f6e21cd"
   integrity sha512-ZY2H1PH05Yhn22B7G8ilLyIT9LxQ9b/PyErkPx8OOW+znary5QgExMhgBl1Gmv3k9m/QX1qIxKHZveO4R2yfeA==
 
-"@joystream/warthog@^2.35.0":
-  version "2.35.0"
-  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.35.0.tgz#da6d735a81ac64eb1dc9fb7ce6ea103b24f236c3"
-  integrity sha512-rxhPjtbN+V2cnFR4kSkn98B2qrL6jWwQzlHqd18S3Am6izotvdVcXInPTqTCRGsdVvmgrrHOduUqzLLiKjed3A==
+"@joystream/warthog@^2.36.0":
+  version "2.36.0"
+  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.36.0.tgz#f470d00a71424a98467c2802ca391038f72a007d"
+  integrity sha512-uHlvaMrDW31NofNXRgbNXA54aF2+EOsW1ZJnOwFHkrsnGeXUrLEnMhJTdPLKpHMHNtpdSXaj+bp6YgBvopHf8g==
   dependencies:
     "@types/app-root-path" "^1.2.4"
     "@types/bn.js" "^4.11.6"


### PR DESCRIPTION
This PR upgrade warthog version to resolve #444 but doesn't resolve *filtering depth*

affects: @joystream/hydra-cli