### PR TITLE
docs: fix Sample project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ The monorepo contains the following sub-packages:
 * [Hydra Indexer Gateway](hydra-indexer-gateway.md): GraphQL interface for the Indexer
 * [Hydra Processor](hydra-processor.md): Processing part of the pipeline for transforming events into rich business-level objects
 * [Hydra Typegen](hydra-typegen.md): A tool for generating typesafe typescript classes for events and extrinsics from the runtime metadata. No more manual deserialization of the event data.
-* [Sample Project](https://github.com/dzhelezov/hydra/tree/e71d8145d55183b406ee4ac5a47b4bd089976e6f/packages/sample/README.md): A quickstart Hydra project set up against a publicly available Kusama indexer. Good starting point.
+* [Sample Project](packages/sample): A quickstart Hydra project set up against a publicly available Kusama indexer. Good starting point.
 * [Docs](https://dzhelezov.gitbook.io/hydra/): In-depth documentation covering the Hydra pipeline and API features, such as full-text search, pagination, extensive filtering and a rich GraphQL dialect defining your schema!
 


### PR DESCRIPTION
It was a bit confusing jumping over repos to see one thing or the other :)

related: Is the hydra documentation, currently on https://dzhelezov.gitbook.io/hydra, reachable from joystream.org? It could be updated too within this PR.