### PR TITLE
Fixes based on Olympia/Giza workarounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "resolutions": {
     "typeorm": "0.2.34",
-    "@polkadot/types": "4.16.2"
+    "@polkadot/types": "5.9.1"
   },
   "lint-staged": {
     "*.ts": "yarn lint --fix"

--- a/packages/bn-typeorm/package.json
+++ b/packages/bn-typeorm/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "scripts": {
     "pub": "yarn build && yarn publish --access public",
-    "build": "rm -rf lib && tsc --build tsconfig.json",
+    "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "prepack": "yarn build",
     "lint": "eslint . --cache --ext .ts"
   },
@@ -27,7 +27,7 @@
     "eslint": "^7.12.1",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "ts-node": "^9.0.0",
-    "typescript": "^3.8"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-cli/package.json
+++ b/packages/hydra-cli/package.json
@@ -48,7 +48,7 @@
     "@inquirer/input": "^0.0.13-alpha.0",
     "@inquirer/password": "^0.0.12-alpha.0",
     "@inquirer/select": "^0.0.13-alpha.0",
-    "@joystream/warthog": "2.41",
+    "@joystream/warthog": "~2.41.1",
     "@oclif/command": "^1.5.20",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
@@ -80,7 +80,7 @@
     "lodash": "^4.17.20",
     "pg": "^8.3.2",
     "pg-listen": "^1.7.0",
-    "@joystream/warthog": "2.41"
+    "@joystream/warthog": "~2.41.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/packages/hydra-cli/package.json
+++ b/packages/hydra-cli/package.json
@@ -38,17 +38,17 @@
     "oclif"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc --build tsconfig.json",
+    "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "postpack": "rm -f oclif.manifest.json",
     "lint": "eslint . --cache --ext .ts",
-    "prepack": "rm -rf lib && tsc -b && cp -R ./src/templates ./lib/src/templates && oclif-dev manifest",
+    "prepack": "rm -rf lib && yarn tsc -b && cp -R ./src/templates ./lib/src/templates && oclif-dev manifest",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@inquirer/input": "^0.0.13-alpha.0",
     "@inquirer/password": "^0.0.12-alpha.0",
     "@inquirer/select": "^0.0.13-alpha.0",
-    "@joystream/warthog": "^2.40.0",
+    "@joystream/warthog": "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz",
     "@oclif/command": "^1.5.20",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
@@ -80,7 +80,7 @@
     "lodash": "^4.17.20",
     "pg": "^8.3.2",
     "pg-listen": "^1.7.0",
-    "@joystream/warthog": "^2.40.0"
+    "@joystream/warthog": "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.0.tgz"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
@@ -102,7 +102,7 @@
     "prettier": "^2.0.5",
     "spawn-command": "^0.0.2-1",
     "temp": "^0.9.1",
-    "ts-node": "^8",
-    "typescript": "^3.9.3"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-cli/package.json
+++ b/packages/hydra-cli/package.json
@@ -48,7 +48,7 @@
     "@inquirer/input": "^0.0.13-alpha.0",
     "@inquirer/password": "^0.0.12-alpha.0",
     "@inquirer/select": "^0.0.13-alpha.0",
-    "@joystream/warthog": "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz",
+    "@joystream/warthog": "2.41",
     "@oclif/command": "^1.5.20",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
@@ -80,7 +80,7 @@
     "lodash": "^4.17.20",
     "pg": "^8.3.2",
     "pg-listen": "^1.7.0",
-    "@joystream/warthog": "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.0.tgz"
+    "@joystream/warthog": "2.41"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
@@ -22,7 +22,20 @@ class CustomNamingStrategy extends SnakeNamingStrategy {
 async function bootstrap() {
   loadConfig();
 
-  const server = getServer({}, { namingStrategy: new CustomNamingStrategy(), maxQueryExecutionTime: 1000, logging: [ process.env.WARTHOG_DB_LOGGING || "error"] });
+  const server = getServer(
+    {
+      playgroundConfig: {
+        version: process.env.GRAPHQL_PLAYGROUND_VERSION || undefined,
+        cdnUrl: process.env.GRAPHQL_PLAYGROUND_CDN_URL || undefined,
+        subscriptionEndpoint: process.env.GRAPHQL_PLAYGROUND_SUBSCRIPTION_ENDPOINT || undefined,
+      }
+    },
+    {
+      namingStrategy: new CustomNamingStrategy(),
+      maxQueryExecutionTime: 1000,
+      logging: [ process.env.WARTHOG_DB_LOGGING || "error"]
+    }
+  );
 
   // Create database tables. Warthog migrate command does not support CustomNamingStrategy thats why
   // we have this code

--- a/packages/hydra-cli/src/templates/graphql-server/tsconfig.json.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/tsconfig.json.mst
@@ -19,7 +19,8 @@
     "strictNullChecks": true,
     "types": ["isomorphic-fetch", "node"],
     "esModuleInterop": true,
-    "declaration": true
+    "declaration": true,
+    "useUnknownInCatchVariables": false
   },
   "include": ["src/**/*", "db/**/*", "model/**/*"],
   "exclude": ["node_modules/**/*", "generated/**/*", "tools/**/*"]

--- a/packages/hydra-cli/src/templates/scaffold/mappings/package.json.mst
+++ b/packages/hydra-cli/src/templates/scaffold/mappings/package.json.mst
@@ -5,19 +5,19 @@
   "main": "lib/mappings/index.js",
   "license": "MIT",
   "scripts": {
-    "build": "rimraf lib && tsc --build tsconfig.json && copyfiles generated/**/*.json lib/mappings",
+    "build": "rimraf lib && yarn --cwd .. tsc --build ./mappings/tsconfig.json && copyfiles generated/**/*.json lib/mappings",
     "lint": "echo \"Skippinng\"",
     "clean": "rimraf lib"
   },
   "dependencies": {
     "@joystream/hydra-common": "{{{hydraCommonVersion}}}",
-    "@polkadot/types": "~2.10.2-7",
+    "@polkadot/types": "5.9.1",
     "@joystream/warthog": "{{{hydraWarthogVersion}}}"
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^9.0.0",
-    "typescript": "^3.8"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-cli/src/templates/textsearch/service.ts.mst
+++ b/packages/hydra-cli/src/templates/textsearch/service.ts.mst
@@ -45,7 +45,7 @@ export class {{query.typePrefix}}FTSService {
 
       const generateSqlQuery = (table: string, joins: string, where: string, having: string) =>
         `
-  SELECT '${table}_' || "${table}_"."id" AS unique_id FROM "${table}" ` + joins + ' ' + where + ' ' + having;
+  SELECT '${table}_' || "${table}"."id" AS unique_id FROM "${table}" ` + joins + ' ' + where + ' ' + having;
 
       wheres.map((w, index) => {
         if (w) {

--- a/packages/hydra-cli/src/templates/textsearch/service.ts.mst
+++ b/packages/hydra-cli/src/templates/textsearch/service.ts.mst
@@ -43,9 +43,9 @@ export class {{query.typePrefix}}FTSService {
       const repositories = [{{#entities}}this.{{fieldName}}Repository, {{/entities}}]
       let [queries, parameters, parameterCounter]: [string, any[], number] = [``, [], 0];
 
-      const generateSqlQuery = (table: string, where: string) =>
+      const generateSqlQuery = (table: string, joins: string, where: string, having: string) =>
         `
-  SELECT '${table}_' || id AS unique_id FROM "${table}" ` + where;
+  SELECT '${table}_' || id AS unique_id FROM "${table}" ` + joins + ' ' + where + ' ' + having;
 
       wheres.map((w, index) => {
         if (w) {
@@ -98,7 +98,7 @@ export class {{query.typePrefix}}FTSService {
           WHERE = WHERE.slice(0, -4);
 
           // Add new query to queryString
-          queries = queries.concat(generateSqlQuery(repositories[index].metadata.tableName, WHERE));
+          queries = queries.concat(generateSqlQuery(repositories[index].metadata.tableName, qb.createJoinExpression(), WHERE, qb.createHavingExpression()));
         }
       });
 

--- a/packages/hydra-cli/src/templates/textsearch/service.ts.mst
+++ b/packages/hydra-cli/src/templates/textsearch/service.ts.mst
@@ -45,7 +45,7 @@ export class {{query.typePrefix}}FTSService {
 
       const generateSqlQuery = (table: string, joins: string, where: string, having: string) =>
         `
-  SELECT '${table}_' || id AS unique_id FROM "${table}" ` + joins + ' ' + where + ' ' + having;
+  SELECT '${table}_' || "${table}_"."id" AS unique_id FROM "${table}" ` + joins + ' ' + where + ' ' + having;
 
       wheres.map((w, index) => {
         if (w) {

--- a/packages/hydra-common/package.json
+++ b/packages/hydra-common/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "scripts": {
     "pub": "yarn build && yarn publish --access public",
-    "build": "rm -rf lib && tsc --build tsconfig.json",
+    "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "lint": "eslint . --cache --ext .ts",
     "prepack": "yarn build",
     "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only \"src/**/*.test.ts\""
@@ -27,7 +27,7 @@
     "@types/debug": "^4.1.5",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "ts-node": "^9.0.0",
-    "typescript": "^3.8"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-db-utils/package.json
+++ b/packages/hydra-db-utils/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "scripts": {
     "pub": "yarn build && yarn publish --access public",
-    "build": "rm -rf lib && tsc --build tsconfig.json",
+    "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "lint": "eslint . --cache --ext .ts",
     "prepack": "yarn build",
     "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only \"test/**/*.test.ts\""
@@ -32,7 +32,7 @@
     "@types/shortid": "^0.0.29",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "ts-node": "^9.0.0",
-    "typescript": "^3.8"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-e2e-tests/package.json
+++ b/packages/hydra-e2e-tests/package.json
@@ -22,8 +22,8 @@
     "e2e-test": "bash run-tests.sh"
   },
   "dependencies": {
-    "@polkadot/api": "4.16.2",
-    "@polkadot/keyring": "6.9.1",
+    "@polkadot/api": "5.9.1",
+    "@polkadot/keyring": "7.9.2",
     "fetch": "^1.1.0",
     "graphql-request": "^3.3.0",
     "graphql-subscriptions-client": "^0.16.0",
@@ -40,7 +40,7 @@
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.0.3"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-indexer-gateway/package.json
+++ b/packages/hydra-indexer-gateway/package.json
@@ -44,7 +44,7 @@
     "@joystream/bn-typeorm": "^3.1.0-alpha.14",
     "@joystream/hydra-common": "^3.1.0-alpha.14",
     "@joystream/hydra-db-utils": "^3.1.0-alpha.14",
-    "@joystream/warthog": "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz",
+    "@joystream/warthog": "2.41",
     "@types/ioredis": "^4.17.4",
     "bn.js": "^5.1.3",
     "dotenv": "^8.2.0",

--- a/packages/hydra-indexer-gateway/package.json
+++ b/packages/hydra-indexer-gateway/package.json
@@ -44,7 +44,7 @@
     "@joystream/bn-typeorm": "^3.1.0-alpha.14",
     "@joystream/hydra-common": "^3.1.0-alpha.14",
     "@joystream/hydra-db-utils": "^3.1.0-alpha.14",
-    "@joystream/warthog": "^2.40.0",
+    "@joystream/warthog": "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz",
     "@types/ioredis": "^4.17.4",
     "bn.js": "^5.1.3",
     "dotenv": "^8.2.0",
@@ -64,9 +64,9 @@
     "eslint": "^7.9.0",
     "jest": "^24.9.0",
     "ts-jest": "^24.1.0",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.2.1",
     "ts-node-dev": "^1.0.0-pre.63",
-    "typescript": "^3.9.7"
+    "typescript": "4.4.2"
   },
   "jest": {
     "globals": {

--- a/packages/hydra-indexer-gateway/package.json
+++ b/packages/hydra-indexer-gateway/package.json
@@ -44,7 +44,7 @@
     "@joystream/bn-typeorm": "^3.1.0-alpha.14",
     "@joystream/hydra-common": "^3.1.0-alpha.14",
     "@joystream/hydra-db-utils": "^3.1.0-alpha.14",
-    "@joystream/warthog": "2.41",
+    "@joystream/warthog": "~2.41.1",
     "@types/ioredis": "^4.17.4",
     "bn.js": "^5.1.3",
     "dotenv": "^8.2.0",

--- a/packages/hydra-indexer/package.json
+++ b/packages/hydra-indexer/package.json
@@ -18,7 +18,7 @@
     "docker:build": "docker build . -t hydra-indexer:latest",
     "docker:tag": "docker tag hydra-indexer:latest joystream/hydra-indexer:v${VERSION_TAG} && docker tag hydra-indexer:latest joystream/hydra-indexer:${MAJOR_VERSION_TAG} && docker tag hydra-indexer:latest joystream/hydra-indexer:${RELEASE_TAG:-next}",
     "docker:publish": "export VERSION_TAG=$(node -p 'require(\"./package.json\").version') && export MAJOR_VERSION_TAG=$(echo $VERSION_TAG|cut -d'.' -f1) && yarn docker:build && yarn docker:tag && docker push joystream/hydra-indexer --all-tags",
-    "build": "rm -rf lib && tsc --build tsconfig.json",
+    "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "lint": "eslint . --cache --ext .ts",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js",
     "i-test": "docker-compose -f docker-compose-test.yml up -d && sh ./run-integration-tests.sh",
@@ -39,7 +39,7 @@
     "@joystream/bn-typeorm": "^3.1.0-alpha.14",
     "@joystream/hydra-common": "^3.1.0-alpha.14",
     "@joystream/hydra-db-utils": "^3.1.0-alpha.14",
-    "@polkadot/api": "4.16.2",
+    "@polkadot/api": "5.9.1",
     "@types/express": "^4.17.8",
     "@types/ioredis": "^4.17.4",
     "@types/lodash": "^4.14.161",
@@ -94,7 +94,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "ts-mockito": "^2.6.1",
-    "ts-node": "^9.0.0",
-    "typescript": "^3.8"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -28,9 +28,9 @@
   "scripts": {
     "pub": "yarn build && yarn publish --access public",
     "run-dev": "node ./bin/run",
-    "build": "rm -rf lib && tsc --build tsconfig.json",
+    "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "postpack": "rm -f oclif.manifest.json",
-    "test-build": "rm -rf test-lib && tsc --build ./test/tsconfig.json",
+    "test-build": "rm -rf test-lib && yarn tsc --build ./test/tsconfig.json",
     "prepack": "yarn build && oclif-dev manifest",
     "lint": "eslint . --cache --ext .ts",
     "test": "bash run-tests.sh",
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@joystream/hydra-cli": "^3.1.0-alpha.14",
-    "@polkadot/api": "4.16.2",
+    "@polkadot/api": "5.9.1",
     "@types/bn.js": "^4.11.6",
     "@types/chai": "^4.2.19",
     "@types/express": "^4.17.8",
@@ -78,11 +78,11 @@
     "pm2": "^5.1.0",
     "ts-auto-mock": "^3.1.2",
     "ts-mock-imports": "^1.3.3",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.2.1",
     "ts-sinon": "^2.0.1",
     "tslib": "^2.0.3",
     "typeorm": "^0.2.34",
-    "typescript": "^3.8",
+    "typescript": "4.4.2",
     "ws": "^8.2.2"
   }
 }

--- a/packages/hydra-processor/src/db/subscribers.ts
+++ b/packages/hydra-processor/src/db/subscribers.ts
@@ -44,11 +44,11 @@ function sanitizeEntity(entity: Entity, entityMetadata: EntityMetadata) {
   Replaces string made of only UTF-8 null characters by an empty string.
 */
 function sanitizeNullCharacter(entity: Record<string, string>, field: string) {
-  if (!entity[field] || !entity[field].match('\0+')) {
+  if (!entity || !entity[field] || !entity[field].match(/\u0000/)) {
     return
   }
 
-  entity[field] = ''
+  entity[field] = entity[field].replace(/\u0000/g, '')
 }
 
 // cache for list of entity string fields

--- a/packages/hydra-processor/src/db/subscribers.ts
+++ b/packages/hydra-processor/src/db/subscribers.ts
@@ -44,11 +44,11 @@ function sanitizeEntity(entity: Entity, entityMetadata: EntityMetadata) {
   Replaces string made of only UTF-8 null characters by an empty string.
 */
 function sanitizeNullCharacter(entity: Record<string, string>, field: string) {
-  if (!entity || !entity[field] || !entity[field].match(/\u0000/)) {
+  if (!entity || !entity[field] || !entity[field].match(/\0/)) {
     return
   }
 
-  entity[field] = entity[field].replace(/\u0000/g, '')
+  entity[field] = entity[field].replace(/\0/g, '')
 }
 
 // cache for list of entity string fields

--- a/packages/hydra-processor/tsconfig.json
+++ b/packages/hydra-processor/tsconfig.json
@@ -14,7 +14,8 @@
         "esModuleInterop": true,
         "inlineSources": false,
         "allowSyntheticDefaultImports": true,
-        "types": [ "node", "@types/node", "mocha", "@types/mocha", "chai" ]
+        "types": [ "node", "@types/node", "mocha", "@types/mocha", "chai" ],
+        "useUnknownInCatchVariables": false
     },
     "include": ["src/**/*"],
 	"exclude": ["node_modules"]

--- a/packages/hydra-typegen/package.json
+++ b/packages/hydra-typegen/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "clean": "rimraf lib/",
     "copy-templates": "copyfiles -u 1 src/**/*.hbs lib/",
-    "build": "yarn clean && tsc && yarn copy-templates",
+    "build": "yarn clean && yarn tsc && yarn copy-templates",
     "run-dev": "node ./bin/run",
     "postpack": "rm -f oclif.manifest.json",
     "lint": "eslint . --cache --ext .ts",
@@ -41,7 +41,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
-    "@polkadot/api": "4.16.2",
+    "@polkadot/api": "5.9.1",
     "debug": "^4.3.1",
     "handlebars": "^4.7.6",
     "lodash": "^4.17.20",
@@ -59,8 +59,8 @@
     "mocha": "^8.2.1",
     "rimraf": "^3.0.2",
     "tmp": "^0.2.1",
-    "ts-node": "^7.0.1",
+    "ts-node": "^10.2.1",
     "ts-node-dev": "^1.0.0-pre.40",
-    "typescript": "^4.1.3"
+    "typescript": "4.4.2"
   }
 }

--- a/packages/hydra-typegen/src/generators/helpers.spec.ts
+++ b/packages/hydra-typegen/src/generators/helpers.spec.ts
@@ -22,10 +22,8 @@ describe('helpers', () => {
       args: ['Type1', 'Type2 & Balance'],
     })
     expect(c(prmsReturnStmt())).to.equal(
-      c(`return [createTypeUnsafe<Type1 & Codec>(
-            typeRegistry, 'Type1', [this.ctx.params[0].value]), 
-            createTypeUnsafe<Type2 & Balance & Codec>(
-            typeRegistry, 'Type2 & Balance', [this.ctx.params[1].value])]`)
+      c(`return [createTypeUnsafe(typeRegistry, 'Type1', [this.ctx.params[0].value]), 
+            createTypeUnsafe(typeRegistry, 'Type2 & Balance', [this.ctx.params[1].value])]`)
     )
   })
 
@@ -34,8 +32,9 @@ describe('helpers', () => {
       args: ['Vec<(Type1,Type2,(Balance1,Balance2))>'],
     })
     expect(c(prmsReturnStmt())).to.equal(
-      c(`return [createTypeUnsafe<Vec<[Type1,Type2,[Balance1,Balance2] & Codec] & Codec> & Codec>(
-            typeRegistry, 'Vec<(Type1,Type2,(Balance1,Balance2))>', [this.ctx.params[0].value])]`)
+      c(
+        `return [createTypeUnsafe(typeRegistry, 'Vec<(Type1,Type2,(Balance1,Balance2))>', [this.ctx.params[0].value])]`
+      )
     )
   })
 })

--- a/packages/hydra-typegen/src/generators/helpers.ts
+++ b/packages/hydra-typegen/src/generators/helpers.ts
@@ -58,8 +58,7 @@ export function renderTypedParams(argTypes: string[]): string {
 }
 
 function renderCreateTypeStmt(argType: string, ctxValueGetter: string) {
-  return `createTypeUnsafe<${convertTuples(argType)} & Codec>(
-            typeRegistry, '${argType}', ${ctxValueGetter}) `
+  return `createTypeUnsafe(typeRegistry, '${argType}', ${ctxValueGetter}) `
 }
 
 /**

--- a/packages/hydra-typegen/src/metadata/metadata.ts
+++ b/packages/hydra-typegen/src/metadata/metadata.ts
@@ -1,5 +1,5 @@
 import { MetadataLatest } from '@polkadot/types/interfaces'
-import { Metadata } from '@polkadot/metadata'
+import { Metadata } from '@polkadot/types'
 import { TypeRegistry } from '@polkadot/types/create'
 import { WebSocket } from '@polkadot/x-ws'
 import BN from 'bn.js'

--- a/packages/sample/mappings/package.json
+++ b/packages/sample/mappings/package.json
@@ -6,18 +6,18 @@
   "main": "lib/mappings/index.js",
   "license": "MIT",
   "scripts": {
-    "build": "rimraf lib && tsc --build tsconfig.json && copyfiles generated/**/*.json lib/mappings",
+    "build": "rimraf lib && yarn tsc --build tsconfig.json && copyfiles generated/**/*.json lib/mappings",
     "lint": "echo \"Skippinng\"",
     "clean": "rimraf lib"
   },
   "dependencies": {
     "@joystream/hydra-common": "^3.1.0-alpha.14",
-    "@polkadot/types": "4.2.1"
+    "@polkadot/types": "5.9.1"
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^9.0.0",
-    "typescript": "^3.8"
+    "ts-node": "^10.2.1",
+    "typescript": "4.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@joystream/prettier-config/-/prettier-config-1.0.0.tgz#d87c6370244f39281d9052c619977ca60f6e21cd"
   integrity sha512-ZY2H1PH05Yhn22B7G8ilLyIT9LxQ9b/PyErkPx8OOW+znary5QgExMhgBl1Gmv3k9m/QX1qIxKHZveO4R2yfeA==
 
-"@joystream/warthog@2.41":
-  version "2.41.0"
-  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.41.0.tgz#c5e97b75e041fdcf4c84a01bfa79482614e83bfc"
-  integrity sha512-0TsHFa78wWC1iAIHA883BEO1pYv8tu6rugCHpTT+9OLUcq9cJ8/sGrNtECDRbAJixI66OcSeDZGrTy3BBd7WKg==
+"@joystream/warthog@~2.41.1":
+  version "2.41.1"
+  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.41.1.tgz#060be37d988c11fd74b457c663811ad21e1b0e86"
+  integrity sha512-ysUaivwy8slX2B5jeFVV8pgwfzdDTPTHh5focqQJJCHhGBbNmzIkjXcRKehRrKypJe3xoDO75PhvoI/x67ELnQ==
   dependencies:
     "@apollographql/graphql-playground-react" "https://github.com/Joystream/graphql-playground/releases/download/query-templates%401.7.27/graphql-playground-react-v1.7.27.tgz"
     "@types/app-root-path" "^1.2.4"
@@ -1235,7 +1235,7 @@
     typedi "^0.8.0"
     typeorm "0.2.37"
     typeorm-typedi-extensions "^0.4.1"
-    typescript "^3.9.7"
+    typescript "^4.4"
 
 "@lerna/add@3.21.0":
   version "3.21.0"
@@ -16215,10 +16215,10 @@ typescript@4.4.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
-typescript@^3.9.7:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@^4.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 typescript@^4.4.3:
   version "4.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,17 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.3", "@babel/runtime@^7.15.4", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.15.4", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.16.3":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
+  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -605,6 +612,18 @@
   integrity sha512-RRVHEqmk1qn/dIaSQhvuca6k/6Z54G+r/KyimZ8gnAFielGiGUpsFRhIY3qhd5rXClVxDaa3nlcyTWckSccotQ==
   dependencies:
     chalk "^4.0.0"
+
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
@@ -1152,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@joystream/prettier-config/-/prettier-config-1.0.0.tgz#d87c6370244f39281d9052c619977ca60f6e21cd"
   integrity sha512-ZY2H1PH05Yhn22B7G8ilLyIT9LxQ9b/PyErkPx8OOW+znary5QgExMhgBl1Gmv3k9m/QX1qIxKHZveO4R2yfeA==
 
-"@joystream/warthog@^2.40.0":
-  version "2.40.0"
-  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.40.0.tgz#6384803b0326dd43b554aac65c68838249f1119e"
-  integrity sha512-fNlN0rzCPWvt1lrBXz24UFdwMMJBrrGPB1ObruQXJXTbZeZ+OuqIJLCCw2j+JjeT/Tl569VM4/S69jA+usCfng==
+"@joystream/warthog@https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz":
+  version "2.41.0"
+  uid "5112f6ae1fc2eaa39573593a061583c6ca30f083"
+  resolved "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz#5112f6ae1fc2eaa39573593a061583c6ca30f083"
   dependencies:
     "@apollographql/graphql-playground-react" "https://github.com/Joystream/graphql-playground/releases/download/query-templates%401.7.27/graphql-playground-react-v1.7.27.tgz"
     "@types/app-root-path" "^1.2.4"
@@ -1216,7 +1235,7 @@
     typedi "^0.8.0"
     typeorm "0.2.37"
     typeorm-typedi-extensions "^0.4.1"
-    typescript "^3.9.7"
+    typescript "^4.4"
 
 "@lerna/add@3.21.0":
   version "3.21.0"
@@ -2288,104 +2307,75 @@
   dependencies:
     debug "^4.3.1"
 
-"@polkadot/api-derive@4.16.2":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-4.16.2.tgz#8ed97fec7965a1be1c5d87a3639752d5cdfdbc8a"
-  integrity sha512-xRAIGoeULK+E7uep5D0eDUN6m0KcMV4eOPkmvyfp7ndxfaf94ydfEOw+QemrnT1T/chA/qq96EYvuBe3lv5w1Q==
+"@polkadot/api-derive@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-5.9.1.tgz#5937069920ded1439e6672b9d6be1072421b256b"
+  integrity sha512-iMrVKnYIS3UQciDlFqww6AFyXgG+iN8UqWu8QbTuZecri3qrSmM3Nn8Jkvju3meZIacwWIMSmBcnj8+zef3rkQ==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/api" "4.16.2"
-    "@polkadot/rpc-core" "4.16.2"
-    "@polkadot/types" "4.16.2"
-    "@polkadot/util" "^6.10.1"
-    "@polkadot/util-crypto" "^6.10.1"
-    "@polkadot/x-rxjs" "^6.10.1"
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/api" "5.9.1"
+    "@polkadot/rpc-core" "5.9.1"
+    "@polkadot/types" "5.9.1"
+    "@polkadot/util" "^7.3.1"
+    "@polkadot/util-crypto" "^7.3.1"
+    rxjs "^7.3.0"
 
-"@polkadot/api@4.16.2":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-4.16.2.tgz#361fbeb690d8b646387e9f8bec22929aca09d691"
-  integrity sha512-x+fWc7mE3ZuGxoFCTf/Tnv0z7rDTM198M9LnWUJdadyNT3QAtE+Cjgo1bCrroTnuD3whd0jhFLfLQCwz95RrwA==
+"@polkadot/api@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-5.9.1.tgz#ce314cc34f0a47098d039db7b9036bb491c2898c"
+  integrity sha512-POpIXn/Ao+NLB0uMldXdXU44dVbRr6+6Ax77Z0R285M8Z2EiF5jl2K3SPvlowLo4SntxiCSaHQxCekYhUcJKlw==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/api-derive" "4.16.2"
-    "@polkadot/keyring" "^6.10.1"
-    "@polkadot/metadata" "4.16.2"
-    "@polkadot/rpc-core" "4.16.2"
-    "@polkadot/rpc-provider" "4.16.2"
-    "@polkadot/types" "4.16.2"
-    "@polkadot/types-known" "4.16.2"
-    "@polkadot/util" "^6.10.1"
-    "@polkadot/util-crypto" "^6.10.1"
-    "@polkadot/x-rxjs" "^6.10.1"
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/api-derive" "5.9.1"
+    "@polkadot/keyring" "^7.3.1"
+    "@polkadot/rpc-core" "5.9.1"
+    "@polkadot/rpc-provider" "5.9.1"
+    "@polkadot/types" "5.9.1"
+    "@polkadot/types-known" "5.9.1"
+    "@polkadot/util" "^7.3.1"
+    "@polkadot/util-crypto" "^7.3.1"
     eventemitter3 "^4.0.7"
+    rxjs "^7.3.0"
 
-"@polkadot/keyring@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-6.9.1.tgz#a92dd2d4ef8ccb999bc7d443ef4a13e6ef9b2ce2"
-  integrity sha512-UF+9psVwVlar7LRJYWJB/xETYBPu1OcyVrxDe88w17Y+ZIsIeNfcR9quVS4M7AdAhplmscsz/wgEMjmggXH9/Q==
+"@polkadot/keyring@7.9.2", "@polkadot/keyring@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-7.9.2.tgz#1f5bf6b7bdb5942d275aebf72d4ed98abe874fa8"
+  integrity sha512-6UGoIxhiTyISkYEZhUbCPpgVxaneIfb/DBVlHtbvaABc8Mqh1KuqcTIq19Mh9wXlBuijl25rw4lUASrE/9sBqg==
   dependencies:
-    "@babel/runtime" "^7.14.5"
-    "@polkadot/util" "6.9.1"
-    "@polkadot/util-crypto" "6.9.1"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/util" "7.9.2"
+    "@polkadot/util-crypto" "7.9.2"
 
-"@polkadot/keyring@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-6.11.1.tgz#2510c349c965c74cc2f108f114f1048856940604"
-  integrity sha512-rW8INl7pO6Dmaffd6Df1yAYCRWa2RmWQ0LGfJeA/M6seVIkI6J3opZqAd4q2Op+h9a7z4TESQGk8yggOEL+Csg==
+"@polkadot/networks@7.9.2", "@polkadot/networks@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-7.9.2.tgz#03e3f3ac6bdea177517436537826055df60bcb9a"
+  integrity sha512-4obI1RdW5/7TFwbwKA9oqw8aggVZ65JAUvIFMd2YmMC2T4+NiZLnok0WhRkhZkUnqjLIHXYNwq7Ho1i39dte0g==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/util" "6.11.1"
-    "@polkadot/util-crypto" "6.11.1"
+    "@babel/runtime" "^7.16.3"
 
-"@polkadot/metadata@4.16.2":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-4.16.2.tgz#2a90c9e6ac500ee1b176a5e0e08b64c8d7bf5458"
-  integrity sha512-wx5DwAxV8zEDQzgdeDFRRlDb89CqmgY/eKusvMgzRuLG5Z4Hu4jxQ6LnBsjVmA70BBhgs+uAuJ7mzY76OO4wDw==
+"@polkadot/rpc-core@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-5.9.1.tgz#68e2a2ea18c15aa15743e7487a407fdd65d1d900"
+  integrity sha512-5fXiICAcjp7ow81DnIl2Dq/xuCtJUqyjJkxe9jNHJWBluBxOouqYDb8bYPPGSdckiaVyYe0l8lA9fBUFMdEt6w==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/types" "4.16.2"
-    "@polkadot/types-known" "4.16.2"
-    "@polkadot/util" "^6.10.1"
-    "@polkadot/util-crypto" "^6.10.1"
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/rpc-provider" "5.9.1"
+    "@polkadot/types" "5.9.1"
+    "@polkadot/util" "^7.3.1"
+    rxjs "^7.3.0"
 
-"@polkadot/networks@6.11.1", "@polkadot/networks@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-6.11.1.tgz#8fd189593f6ee4f8bf64378d0aaae09e39a37d35"
-  integrity sha512-0C6Ha2kvr42se3Gevx6UhHzv3KnPHML0N73Amjwvdr4y0HLZ1Nfw+vcm5yqpz5gpiehqz97XqFrsPRauYdcksQ==
+"@polkadot/rpc-provider@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-5.9.1.tgz#8e67769c05ba71ecf4f5bc0c5a60eb9afc699167"
+  integrity sha512-9zamxfnsY7iCswXIK22W0Ji1XHLprm97js3WLw3lP2hr/uSim4Cv4y07zY/z4dDQyF0gJtjKwR27Wo9CZqdr6A==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-
-"@polkadot/networks@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-6.9.1.tgz#8d66338569c9891a00cc6737e18c1dbffd7153f5"
-  integrity sha512-imBPIrLN0W+7zuosD4WBtOkMzXc/271NhWn6dQmyA0xEoJx+6coJHQH/04fqO/gfZd4M1R70f3Gt5hlsfzCwlA==
-  dependencies:
-    "@babel/runtime" "^7.14.5"
-
-"@polkadot/rpc-core@4.16.2":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-4.16.2.tgz#a839407a1c00048a10ed711ad3dd1b52f8fd20cc"
-  integrity sha512-NAMkN5rtccLL7G0aeMqxx/R38exkJ/xVNEZh9Y/okw8w0iOCnZk72ge9ABkd/SJbLxm6l+5c87cTXUK77r1zTQ==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/metadata" "4.16.2"
-    "@polkadot/rpc-provider" "4.16.2"
-    "@polkadot/types" "4.16.2"
-    "@polkadot/util" "^6.10.1"
-    "@polkadot/x-rxjs" "^6.10.1"
-
-"@polkadot/rpc-provider@4.16.2":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-4.16.2.tgz#73a0b6818ec57d10b735b1e471eb7d88dd8a39db"
-  integrity sha512-aAq3mHkgHziQrZQdNuxGSrkKKksA8Kk0N8WWsW1DZOkjt7rlF3vdmCguHTPlOzO4NHmeDsGVlGGBzjOza8QNbA==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/types" "4.16.2"
-    "@polkadot/util" "^6.10.1"
-    "@polkadot/util-crypto" "^6.10.1"
-    "@polkadot/x-fetch" "^6.10.1"
-    "@polkadot/x-global" "^6.10.1"
-    "@polkadot/x-ws" "^6.10.1"
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/types" "5.9.1"
+    "@polkadot/util" "^7.3.1"
+    "@polkadot/util-crypto" "^7.3.1"
+    "@polkadot/x-fetch" "^7.3.1"
+    "@polkadot/x-global" "^7.3.1"
+    "@polkadot/x-ws" "^7.3.1"
     eventemitter3 "^4.0.7"
 
 "@polkadot/ts@^0.3.14":
@@ -2395,210 +2385,133 @@
   dependencies:
     "@types/chrome" "^0.0.145"
 
-"@polkadot/types-known@4.16.2":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-4.16.2.tgz#94e54adb3ba767342f9aed226eb4aa973520b911"
-  integrity sha512-ydeS1SnO25O//TThzUBYjthCOH3h70j1IRVQ+CPVhVbZJoMRr47hIysFTBjyxyKVTQtj20vniZV8+qq6oiWggA==
+"@polkadot/types-known@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-5.9.1.tgz#e52fc7b803bc7cb3f41028f88963deb4ccee40af"
+  integrity sha512-7lpLuIVGaKziQRzPMnTxyjlYy3spL6WqUg3CcEzmJUKQeUonHglOliQh8JSSz1bcP+YuNHGXK1cKsTjHb+GYxA==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/networks" "^6.10.1"
-    "@polkadot/types" "4.16.2"
-    "@polkadot/util" "^6.10.1"
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/networks" "^7.3.1"
+    "@polkadot/types" "5.9.1"
+    "@polkadot/util" "^7.3.1"
 
-"@polkadot/types@4.16.2", "@polkadot/types@4.2.1":
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-4.16.2.tgz#06dfedf19a50d659863c068ba1444efbc214c302"
-  integrity sha512-JSIvVKIBhRHCswDPYMoy4TLvR9O1NT5mqyIBoLjNKur0WShLk1jVtiyKbU+2/AuCbM1nehiWagmAlWmMFNaDMw==
+"@polkadot/types@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-5.9.1.tgz#74cf4695795f2aa365ff85d3873e22c430100bc9"
+  integrity sha512-30vcSlNBxPyWYZaxKDr/BoMhfLCRKB265XxpnnNJmbdZZsL+N4Zp2mJR9/UbA6ypmJBkUjD7b1s9AYsLwUs+8w==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/metadata" "4.16.2"
-    "@polkadot/util" "^6.10.1"
-    "@polkadot/util-crypto" "^6.10.1"
-    "@polkadot/x-rxjs" "^6.10.1"
+    "@babel/runtime" "^7.15.4"
+    "@polkadot/util" "^7.3.1"
+    "@polkadot/util-crypto" "^7.3.1"
+    rxjs "^7.3.0"
 
-"@polkadot/util-crypto@6.11.1", "@polkadot/util-crypto@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-6.11.1.tgz#7a36acf5c8bf52541609ec0b0b2a69af295d652e"
-  integrity sha512-fWA1Nz17FxWJslweZS4l0Uo30WXb5mYV1KEACVzM+BSZAvG5eoiOAYX6VYZjyw6/7u53XKrWQlD83iPsg3KvZw==
+"@polkadot/util-crypto@7.9.2", "@polkadot/util-crypto@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-7.9.2.tgz#cdc336f92a6bc3d40c5a23734e1974fb777817f0"
+  integrity sha512-nNwqUwP44eCH9jKKcPie+IHLKkg9LMe6H7hXo91hy3AtoslnNrT51tP3uAm5yllhLvswJfnAgnlHq7ybCgqeFw==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/networks" "6.11.1"
-    "@polkadot/util" "6.11.1"
-    "@polkadot/wasm-crypto" "^4.0.2"
-    "@polkadot/x-randomvalues" "6.11.1"
-    base-x "^3.0.8"
-    base64-js "^1.5.1"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/networks" "7.9.2"
+    "@polkadot/util" "7.9.2"
+    "@polkadot/wasm-crypto" "^4.4.1"
+    "@polkadot/x-randomvalues" "7.9.2"
     blakejs "^1.1.1"
-    bn.js "^4.11.9"
+    bn.js "^4.12.0"
     create-hash "^1.2.0"
+    ed2curve "^0.3.0"
     elliptic "^6.5.4"
     hash.js "^1.1.7"
     js-sha3 "^0.8.0"
+    micro-base "^0.9.0"
     scryptsy "^2.1.0"
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util-crypto@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-6.9.1.tgz#175a2bbc040785599730baee35f0235226b8343e"
-  integrity sha512-lniY8bhRoayA8PD3NHyvpAL2N9YETDll6HbxaOIkGS9nnVmlOjIvslcd343b30rj7/qSV72w+8qkReHj650aQw==
+"@polkadot/util@7.9.2", "@polkadot/util@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-7.9.2.tgz#567ac659516d6b685ed7e796919901d92e5cbe6b"
+  integrity sha512-6ABY6ErgkCsM4C6+X+AJSY4pBGwbKlHZmUtHftaiTvbaj4XuA4nTo3GU28jw8wY0Jh2cJZJvt6/BJ5GVkm5tBA==
   dependencies:
-    "@babel/runtime" "^7.14.5"
-    "@polkadot/networks" "6.9.1"
-    "@polkadot/util" "6.9.1"
-    "@polkadot/wasm-crypto" "^4.0.2"
-    "@polkadot/x-randomvalues" "6.9.1"
-    base-x "^3.0.8"
-    base64-js "^1.5.1"
-    blakejs "^1.1.0"
-    bn.js "^4.11.9"
-    create-hash "^1.2.0"
-    elliptic "^6.5.4"
-    hash.js "^1.1.7"
-    js-sha3 "^0.8.0"
-    scryptsy "^2.1.0"
-    tweetnacl "^1.0.3"
-    xxhashjs "^0.2.2"
-
-"@polkadot/util@6.11.1", "@polkadot/util@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-6.11.1.tgz#8950b038ba3e6ebfc0a7ff47feeb972e81b2626c"
-  integrity sha512-TEdCetr9rsdUfJZqQgX/vxLuV4XU8KMoKBMJdx+JuQ5EWemIdQkEtMBdL8k8udNGbgSNiYFA6rPppATeIxAScg==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/x-textdecoder" "6.11.1"
-    "@polkadot/x-textencoder" "6.11.1"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/x-textdecoder" "7.9.2"
+    "@polkadot/x-textencoder" "7.9.2"
     "@types/bn.js" "^4.11.6"
-    bn.js "^4.11.9"
-    camelcase "^5.3.1"
+    bn.js "^4.12.0"
+    camelcase "^6.2.1"
     ip-regex "^4.3.0"
 
-"@polkadot/util@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-6.9.1.tgz#009a9e0771523398517dbf3a978285b071f6081c"
-  integrity sha512-RTIn8+Xdgywj8Bl7D12557zi8iIoUvDpAJztp/CwIq4O3jEw6Y/7lqNX/K6OXhZm/gZf7tFgFnvGlsIuNbtYcQ==
+"@polkadot/wasm-crypto-asmjs@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.5.1.tgz#e1025a49e106db11d1187caf65f56c960ea2ad2b"
+  integrity sha512-DOdRiWhxVvmqTvp+E9z1j+Yr0zDOGsDvqnT/eNw0Dl1FVUOImsEa7FKns/urASmcxCVEE1jtUWSnij29jrORMQ==
   dependencies:
-    "@babel/runtime" "^7.14.5"
-    "@polkadot/x-textdecoder" "6.9.1"
-    "@polkadot/x-textencoder" "6.9.1"
-    "@types/bn.js" "^4.11.6"
-    bn.js "^4.11.9"
-    camelcase "^5.3.1"
-    ip-regex "^4.3.0"
+    "@babel/runtime" "^7.16.3"
 
-"@polkadot/wasm-crypto-asmjs@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.2.1.tgz#6b7eae1c011709f8042dfd30872a5fc5e9e021c0"
-  integrity sha512-ON9EBpTNDCI3QRUmuQJIegYoAcwvxDaNNA7uwKTaEEStu8LjCIbQxbt4WbOBYWI0PoUpl4iIluXdT3XZ3V3jXA==
+"@polkadot/wasm-crypto-wasm@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.5.1.tgz#063a58ff7ddd939b7886a6a238109a8d2c416e46"
+  integrity sha512-hPwke85HxpgG/RAlwdCE8u5w7bThvWg399mlB+XjogXMxOUWBZSgq2XYbgzROUXx27inK9nStF4Pnc4zJnqs9A==
   dependencies:
-    "@babel/runtime" "^7.15.3"
+    "@babel/runtime" "^7.16.3"
 
-"@polkadot/wasm-crypto-wasm@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.2.1.tgz#2a86f9b405e7195c3f523798c6ce4afffd19737e"
-  integrity sha512-Rs2CKiR4D+2hKzmKBfPNYxcd2E8NfLWia0av4fgicjT9YsWIWOGQUi9AtSOfazPOR9FrjxKJy+chQxAkcfKMnQ==
+"@polkadot/wasm-crypto@^4.4.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.5.1.tgz#e1ac6d846a0ad8e991cec128994524183ef6e8fd"
+  integrity sha512-Cr21ais3Kq3aedIHZ3J1tjgeD/+K8FCiwEawr0oRywNBSJR8wyuZMePs4swR/6xm8wbBkpqoBVHz/UQHqqQJmA==
   dependencies:
-    "@babel/runtime" "^7.15.3"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/wasm-crypto-asmjs" "^4.5.1"
+    "@polkadot/wasm-crypto-wasm" "^4.5.1"
 
-"@polkadot/wasm-crypto@^4.0.2":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.2.1.tgz#4d09402f5ac71a90962fb58cbe4b1707772a4fb6"
-  integrity sha512-C/A/QnemOilRTLnM0LfhPY2N/x3ZFd1ihm9sXYyuh98CxtekSVYI9h4IJ5Jrgz5imSUHgvt9oJLqJ5GbWQV/Zg==
+"@polkadot/x-fetch@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-7.9.2.tgz#fe943be5854f7355630388b1b5d2bb52f1a3afb2"
+  integrity sha512-zutLkFJVaLVpY3cIGYJD0AReLfAnPr2J82Ca4pvy/BxqwwGYuGLcn36A4m6nliGBP2lcH4oYY+mcCqIwoPWQUQ==
   dependencies:
-    "@babel/runtime" "^7.15.3"
-    "@polkadot/wasm-crypto-asmjs" "^4.2.1"
-    "@polkadot/wasm-crypto-wasm" "^4.2.1"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/x-global" "7.9.2"
+    "@types/node-fetch" "^2.5.12"
+    node-fetch "^2.6.6"
 
-"@polkadot/x-fetch@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-6.11.1.tgz#97d44d78ef0285eec6f6dbc4006302308ec8e24c"
-  integrity sha512-qJyLLnm+4SQEZ002UDz2wWnXbnnH84rIS0mLKZ5k82H4lMYY+PQflvzv6sbu463e/lgiEao+6zvWS6DSKv1Yog==
+"@polkadot/x-global@7.9.2", "@polkadot/x-global@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-7.9.2.tgz#b272b0a3bedaad3bcbf075ec4682abe68cf2a850"
+  integrity sha512-JX5CrGWckHf1P9xKXq4vQCAuMUbL81l2hOWX7xeP8nv4caHEpmf5T1wD1iMdQBL5PFifo6Pg0V6/oZBB+bts7A==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/x-global" "6.11.1"
-    "@types/node-fetch" "^2.5.10"
-    node-fetch "^2.6.1"
+    "@babel/runtime" "^7.16.3"
 
-"@polkadot/x-global@6.11.1", "@polkadot/x-global@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-6.11.1.tgz#c292b3825fea60e9b33fff1790323fc57de1ca5d"
-  integrity sha512-lsBK/e4KbjfieyRmnPs7bTiGbP/6EoCZz7rqD/voNS5qsJAaXgB9LR+ilubun9gK/TDpebyxgO+J19OBiQPIRw==
+"@polkadot/x-randomvalues@7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-7.9.2.tgz#0c9bb7b48a0791c2a32e9605a31a5ce56fee621d"
+  integrity sha512-svQfG31yCXf6yVyIgP0NgCzEy7oc3Lw054ZspkaqjOivxYdrXaf5w3JSSUyM/MRjI2+nk+B/EyJoMYcfSwTfsQ==
   dependencies:
-    "@babel/runtime" "^7.14.6"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/x-global" "7.9.2"
 
-"@polkadot/x-global@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-6.9.1.tgz#c3d7482e2ac62c306379592550d476fc60ce7dfe"
-  integrity sha512-/pVzvQUObccuk/f2BGcs0WMjveLQPr1Qf+uiSF/7ae9BZHIG4ydLz0/Lnzbt4YQkIEaRNvVFD1Vph5hyjo4VCA==
+"@polkadot/x-textdecoder@7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-7.9.2.tgz#a78548e33efeb3a25f761fec9787b2bcae7f0608"
+  integrity sha512-wfwbSHXPhrOAl12QvlIOGNkMH/N/h8PId2ytIjvM/8zPPFB5Il6DWSFLtVapOGEpIFjEWbd5t8Td4pHBVXIEbg==
   dependencies:
-    "@babel/runtime" "^7.14.5"
-    "@types/node-fetch" "^2.5.10"
-    node-fetch "^2.6.1"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/x-global" "7.9.2"
 
-"@polkadot/x-randomvalues@6.11.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-6.11.1.tgz#f006fa250c8e82c92ccb769976a45a8e7f3df28b"
-  integrity sha512-2MfUfGZSOkuPt7GF5OJkPDbl4yORI64SUuKM25EGrJ22o1UyoBnPOClm9eYujLMD6BfDZRM/7bQqqoLW+NuHVw==
+"@polkadot/x-textencoder@7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-7.9.2.tgz#b32bfd6fbff8587c56452f58252a52d62bbcd5b9"
+  integrity sha512-A19wwYINuZwU2dUyQ/mMzB0ISjyfc4cISfL4zCMUAVgj7xVoXMYV2GfjNdMpA8Wsjch3su6pxLbtJ2wU03sRTQ==
   dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/x-global" "6.11.1"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/x-global" "7.9.2"
 
-"@polkadot/x-randomvalues@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-6.9.1.tgz#e289e79849e332777fb96e8544b1193a4e793e59"
-  integrity sha512-L1c5ddjzyPAvzRkbnrbVgQTUskM4vRtfxblOV/tmM1BP6mB1U3rWo0FeHNWN/uiUoibVFIDNUKqUnZ5vhYs1qg==
+"@polkadot/x-ws@^7.3.1":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-7.9.2.tgz#016df26fa829b74f8b1e31a1dcd6e34256c1231f"
+  integrity sha512-+yppMsZtvDztVOSmkqAQuhR6TfV1Axa6ergAsWb52DrfXvFP5geqtARsI6ZdDgMsE3qHSVQTcJz8vgNOr5+ztQ==
   dependencies:
-    "@babel/runtime" "^7.14.5"
-    "@polkadot/x-global" "6.9.1"
-
-"@polkadot/x-rxjs@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-6.11.1.tgz#5454708b61da70eea05708611d9148fce9372498"
-  integrity sha512-zIciEmij7SUuXXg9g/683Irx6GogxivrQS2pgBir2DI/YZq+um52+Dqg1mqsEZt74N4KMTMnzAZAP6LJOBOMww==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    rxjs "^6.6.7"
-
-"@polkadot/x-textdecoder@6.11.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-6.11.1.tgz#6cc314645681cc4639085c03b65328671c7f182c"
-  integrity sha512-DI1Ym2lyDSS/UhnTT2e9WutukevFZ0WGpzj4eotuG2BTHN3e21uYtYTt24SlyRNMrWJf5+TkZItmZeqs1nwAfQ==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/x-global" "6.11.1"
-
-"@polkadot/x-textdecoder@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-6.9.1.tgz#dab6e95b35c9386550c4907fd1efb195ab605ec9"
-  integrity sha512-U7Cu7PbY5CG5kjbKqAQ/e07FfvPYZwHZZbC+343vDHUnJlyONKxp+jhod+A1pepu15fsYH/iZC0Os6RwfKoEAA==
-  dependencies:
-    "@babel/runtime" "^7.14.5"
-    "@polkadot/x-global" "6.9.1"
-
-"@polkadot/x-textencoder@6.11.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-6.11.1.tgz#73e89da5b91954ae380042c19314c90472f59d9e"
-  integrity sha512-8ipjWdEuqFo+R4Nxsc3/WW9CSEiprX4XU91a37ZyRVC4e9R1bmvClrpXmRQLVcAQyhRvG8DKOOtWbz8xM+oXKg==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/x-global" "6.11.1"
-
-"@polkadot/x-textencoder@6.9.1":
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-6.9.1.tgz#cf98a3f248ad9a4cdb2559f950ff6559d009b619"
-  integrity sha512-M9VNm7IpbBwQnCZhEBAXSQ+/g2psEv4zjJYdX4/HTcWNpnYEUHeayIVTw91Wkgo3dN8wBL245vVp/8apfKfMkQ==
-  dependencies:
-    "@babel/runtime" "^7.14.5"
-    "@polkadot/x-global" "6.9.1"
-
-"@polkadot/x-ws@^6.10.1":
-  version "6.11.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-6.11.1.tgz#338adc7309e3a8e660fce8eb42f975426da48d10"
-  integrity sha512-GNu4ywrMlVi0QF6QSpKwYWMK6JRK+kadgN/zEhMoH1z5h8LwpqDLv128j5WspWbQti2teCQtridjf7t2Lzoe8Q==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    "@polkadot/x-global" "6.11.1"
-    "@types/websocket" "^1.0.3"
+    "@babel/runtime" "^7.16.3"
+    "@polkadot/x-global" "7.9.2"
+    "@types/websocket" "^1.0.4"
     websocket "^1.0.34"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
@@ -2761,6 +2674,26 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
@@ -3196,7 +3129,7 @@
   resolved "https://registry.yarnpkg.com/@types/node-emoji/-/node-emoji-1.8.1.tgz#689cb74fdf6e84309bcafce93a135dfecd01de3f"
   integrity sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==
 
-"@types/node-fetch@^2.5.10":
+"@types/node-fetch@^2.5.12":
   version "2.5.12"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
   integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
@@ -3406,7 +3339,7 @@
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.6.5.tgz#e9f5b23ebc51100db7ac38f7e950746f8f580c8b"
   integrity sha512-ilpDKpjjq/w/IyyTuQ38mABdaEzTzTugPyU7DlMCMKd8MMYngnPKhA2TgdO1MfEDED9KVV7uSOL1fDkgwJp/wg==
 
-"@types/websocket@^1.0.3":
+"@types/websocket@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.4.tgz#1dc497280d8049a5450854dd698ee7e6ea9e60b8"
   integrity sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==
@@ -3649,6 +3582,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^5.5.3:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
@@ -3668,6 +3606,11 @@ acorn@^8.2.4:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+
+acorn@^8.4.1:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
+  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -4487,14 +4430,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.8:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
-  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
-  dependencies:
-    safe-buffer "^5.0.1"
-
-base64-js@^1.0.2, base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4567,7 +4503,7 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blakejs@^1.1.0, blakejs@^1.1.1:
+blakejs@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
   integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
@@ -4582,7 +4518,7 @@ bluebird@^3.3.5, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-bn.js@^4.11.9:
+bn.js@^4.11.9, bn.js@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -4935,6 +4871,11 @@ camelcase@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
+camelcase@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
+  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
 camelize@^1.0.0:
   version "1.0.0"
@@ -6650,6 +6591,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ed2curve@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ed2curve/-/ed2curve-0.3.0.tgz#322b575152a45305429d546b071823a93129a05d"
+  integrity sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==
+  dependencies:
+    tweetnacl "1.x.x"
 
 editor@1.0.0:
   version "1.0.0"
@@ -11618,6 +11566,11 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+micro-base@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/micro-base/-/micro-base-0.9.0.tgz#09cfe20285bec0ea97f41dc3d10e3fba3d0266ee"
+  integrity sha512-4+tOMKidYT5nQ6/UNmYrGVO5PMcnJdfuR4NC8HK8s2H61B4itOhA9yrsjBdqGV7ecdtej36x3YSIfPLRmPrspg==
+
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -12107,6 +12060,13 @@ node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
   integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -14547,6 +14507,13 @@ rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.1, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.3.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
+  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+  dependencies:
+    tslib "~2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -15957,6 +15924,24 @@ ts-node-dev@^1.0.0-pre.40, ts-node-dev@^1.0.0-pre.63:
     ts-node "^9.0.0"
     tsconfig "^7.0.0"
 
+ts-node@^10.2.1:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 ts-node@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
@@ -15970,17 +15955,6 @@ ts-node@^7.0.1:
     mkdirp "^0.5.1"
     source-map-support "^0.5.6"
     yn "^2.0.0"
-
-ts-node@^8:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
-    yn "3.1.1"
 
 ts-node@^9, ts-node@^9.0.0:
   version "9.1.1"
@@ -16044,6 +16018,11 @@ tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tsutils@^3.17.1:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -16063,15 +16042,15 @@ tv4@^1.3.0:
   resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.3.0.tgz#d020c846fadd50c855abb25ebaecc68fc10f7963"
   integrity sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=
 
+tweetnacl@1.x.x, tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
-
-tweetnacl@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
-  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 tx2@~1.0.4:
   version "1.0.4"
@@ -16231,12 +16210,17 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@^3.8, typescript@^3.9.3, typescript@^3.9.7:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
-typescript@^4.0.3, typescript@^4.1.3, typescript@^4.4.3:
+typescript@^4.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+
+typescript@^4.4.3:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@joystream/prettier-config/-/prettier-config-1.0.0.tgz#d87c6370244f39281d9052c619977ca60f6e21cd"
   integrity sha512-ZY2H1PH05Yhn22B7G8ilLyIT9LxQ9b/PyErkPx8OOW+znary5QgExMhgBl1Gmv3k9m/QX1qIxKHZveO4R2yfeA==
 
-"@joystream/warthog@https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz":
+"@joystream/warthog@2.41":
   version "2.41.0"
-  uid "5112f6ae1fc2eaa39573593a061583c6ca30f083"
-  resolved "https://github.com/Lezek123/warthog/raw/warthog-2-41/joystream-warthog-v2.41.1.tgz#5112f6ae1fc2eaa39573593a061583c6ca30f083"
+  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.41.0.tgz#c5e97b75e041fdcf4c84a01bfa79482614e83bfc"
+  integrity sha512-0TsHFa78wWC1iAIHA883BEO1pYv8tu6rugCHpTT+9OLUcq9cJ8/sGrNtECDRbAJixI66OcSeDZGrTy3BBd7WKg==
   dependencies:
     "@apollographql/graphql-playground-react" "https://github.com/Joystream/graphql-playground/releases/download/query-templates%401.7.27/graphql-playground-react-v1.7.27.tgz"
     "@types/app-root-path" "^1.2.4"
@@ -1235,7 +1235,7 @@
     typedi "^0.8.0"
     typeorm "0.2.37"
     typeorm-typedi-extensions "^0.4.1"
-    typescript "^4.4"
+    typescript "^3.9.7"
 
 "@lerna/add@3.21.0":
   version "3.21.0"
@@ -16215,10 +16215,10 @@ typescript@4.4.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
-typescript@^4.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+typescript@^3.9.7:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^4.4.3:
   version "4.4.4"


### PR DESCRIPTION
Following a related PR in `Joystream/warthog`: https://github.com/Joystream/warthog/pull/7
**Note that `warthog` dependency needs to be updated after the new version is released!**

Scope:
- Fix `sanitizeNullCharacter` function: https://github.com/Joystream/hydra/commit/3d6abc5e9f0870ca31f8bb21110410ab7af0f55e
- Graphql-server TS4 compatibility (https://github.com/Joystream/hydra/commit/d16fb4f52eaabad5f95c1bade939963f8df02fb1)
- Enable warthog playground config via ENV (https://github.com/Joystream/hydra/commit/33305793c155b68efaf750f576ee42da1391912f)
- Fix search queries relationship filtering (https://github.com/Joystream/hydra/commit/52fc3de893b1fa1c74a0928a9112ba6f11e30337)
- `hydra-typegen` compatibility with TS4 (https://github.com/Joystream/hydra/commit/532a0c4a446cfca203a30b93a0c4e77d7b7d00e2)
- Update dependencies (TypeScript, `@polkadot/api`): https://github.com/Joystream/hydra/commit/6deb797b46ec0640388c0af8b56cca9874ebd04f

Those changes along with https://github.com/Joystream/warthog/pull/7 can be tested on a branch based on `giza_staging` here: https://github.com/Lezek123/substrate-runtime-joystream/tree/giza-query-node-staging