### PR TITLE
Query templates support for GraphQL playground

### DIFF
--- a/packages/hydra-cli/package.json
+++ b/packages/hydra-cli/package.json
@@ -48,7 +48,7 @@
     "@inquirer/input": "^0.0.13-alpha.0",
     "@inquirer/password": "^0.0.12-alpha.0",
     "@inquirer/select": "^0.0.13-alpha.0",
-    "@joystream/warthog": "~2.41.2",
+    "@joystream/warthog": "^2.41.3",
     "@oclif/command": "^1.5.20",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
@@ -80,7 +80,7 @@
     "lodash": "^4.17.20",
     "pg": "^8.3.2",
     "pg-listen": "^1.7.0",
-    "@joystream/warthog": "~2.41.2"
+    "@joystream/warthog": "^2.41.3"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/packages/hydra-cli/src/codegen/WarthogWrapper.ts
+++ b/packages/hydra-cli/src/codegen/WarthogWrapper.ts
@@ -164,6 +164,7 @@ export default class WarthogWrapper {
       'src/pubsub.ts',
       'src/WarthogBaseService.ts',
       'src/processor.resolver.ts',
+      'src/queryTemplates.ts',
       'tsconfig.json',
     ]
 

--- a/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
@@ -8,6 +8,7 @@ import { Logger } from '../src/logger';
 
 import { buildServerSchema, getServer } from './server';
 import { startPgSubsribers } from './pubsub';
+import { queryTemplates } from './queryTemplates'
 
 
 class CustomNamingStrategy extends SnakeNamingStrategy {
@@ -27,7 +28,9 @@ async function bootstrap() {
       playgroundConfig: {
         version: process.env.GRAPHQL_PLAYGROUND_VERSION || undefined,
         cdnUrl: process.env.GRAPHQL_PLAYGROUND_CDN_URL || undefined,
+        endpoint: process.env.GRAPHQL_PLAYGROUND_ENDPOINT || undefined,
         subscriptionEndpoint: process.env.GRAPHQL_PLAYGROUND_SUBSCRIPTION_ENDPOINT || undefined,
+        queryTemplates,
       }
     },
     {

--- a/packages/hydra-cli/src/templates/graphql-server/src/queryTemplates.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/queryTemplates.ts.mst
@@ -1,0 +1,43 @@
+// provides GraphQL query examples to GraphQL PLayground
+// overwrite this generated file with file containing custom templates for your project
+
+import { IQueryTemplate } from '@apollographql/graphql-playground-react/lib/components/Playground/QueryTemplates/templateUtils'
+
+// empty examples by default
+export const queryTemplates: IQueryTemplate[] = []
+
+/* Example of how to create custom template queries
+
+import { IQueryTemplate, queryTemplateUtils } from '@apollographql/graphql-playground-react/lib/components/Playground/QueryTemplates/templateUtils'
+
+// fields that will be ignored by autofill
+const commonIgnoredFields = [
+  'deletedAt',
+  'createdById',
+  'updatedById',
+  'deletedById',
+  'version',
+]
+
+const dataObjectIgnoredFields = [
+  ...commonIgnoredFields,
+
+  // dataObject's `owner` is problematic because it's variant and will need some special handling
+  'owner',
+]
+
+const exampleDate = `"2018-01-31 23:59"`
+
+export const queryTemplates: IQueryTemplate[] = [
+  ...queryTemplateUtils.getOneGetAllTemplates('video', 'videos', 'videos', dataObjectIgnoredFields),
+  {
+    title: 'Featured videos',
+    description: 'Get all featured videos.',
+    ignoredFields: commonIgnoredFields,
+    query: `query {
+      ${queryTemplateUtils.descriptionMarker}
+      videos(where: { isFeatured_eq: true }) { ${queryTemplateUtils.allPropsMarker} }
+    }`,
+  },
+].map(queryTemplateUtils.formatQuery)
+*/

--- a/packages/hydra-indexer-gateway/package.json
+++ b/packages/hydra-indexer-gateway/package.json
@@ -44,7 +44,7 @@
     "@joystream/bn-typeorm": "^3.1.0-alpha.17",
     "@joystream/hydra-common": "^3.1.0-alpha.17",
     "@joystream/hydra-db-utils": "^3.1.0-alpha.17",
-    "@joystream/warthog": "~2.41.2",
+    "@joystream/warthog": "^2.41.3",
     "@types/ioredis": "^4.17.4",
     "bn.js": "^5.1.3",
     "dotenv": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@joystream/prettier-config/-/prettier-config-1.0.0.tgz#d87c6370244f39281d9052c619977ca60f6e21cd"
   integrity sha512-ZY2H1PH05Yhn22B7G8ilLyIT9LxQ9b/PyErkPx8OOW+znary5QgExMhgBl1Gmv3k9m/QX1qIxKHZveO4R2yfeA==
 
-"@joystream/warthog@~2.41.2":
-  version "2.41.2"
-  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.41.2.tgz#6d3cf5c977320d1c77be518e848e011a9699b22d"
-  integrity sha512-1w6aT5P3xiI/HaTtqJrVj4Yp1/gxG8cGTeYgzlwr3iq8J11skwE4rLCHQucHfVueyBX49AaqWrhl+wI2ACqk4Q==
+"@joystream/warthog@^2.41.3":
+  version "2.41.3"
+  resolved "https://registry.yarnpkg.com/@joystream/warthog/-/warthog-2.41.3.tgz#12f1ff73f29264dd6ebce1c90ff2dad6b1467871"
+  integrity sha512-CM337UO31zHRgkK1RWpvUr3esQIYmLrpqv/yBOgescNLth/MlfnUpDHV/9fCGfquvFdk/HSUyZFy/6KrJrPXjA==
   dependencies:
     "@apollographql/graphql-playground-react" "https://github.com/Joystream/graphql-playground/releases/download/joystream%401.7.28/graphql-playground-react-v1.7.28.tgz"
     "@types/app-root-path" "^1.2.4"


### PR DESCRIPTION
Adds query templates support for GraphQL playground and updates Warthog.

Includes improvements from https://github.com/Joystream/warthog/pull/9 and https://github.com/Joystream/warthog/pull/10 .