### PR TITLE
added support for querying variant fields in *Connection (pagination) queries

### DIFF
--- a/packages/hydra-cli/src/templates/entities/resolver.ts.mst
+++ b/packages/hydra-cli/src/templates/entities/resolver.ts.mst
@@ -116,7 +116,13 @@ export class {{className}}Resolver {
     @Info() info: any
   ): Promise<{{className}}Connection> {
     
-    const rawFields = graphqlFields(info, {}, { excludedFields: ['__typename'] });
+    const rawFields = graphqlFields(info, {}, {});
+    
+    Object.keys(rawFields.edges.node).map((item) => {
+      if (Object.keys(rawFields.edges.node[item]).includes('__typename')) {
+        rawFields.edges.node[item] = {};
+      }
+    });
 
     let result: any = {
       totalCount: 0,


### PR DESCRIPTION
This PR adds support for querying variant fields in `*Connection` (pagination) queries. Previously, the `*Connection` resolver treated the variant field (to be queried) as a relation and thus skipped it while querying the entity from DB.

After this PR is merged, https://github.com/Joystream/joystream/issues/3381 would be resolved.
___
The connection resolver gets [fields](https://github.com/Joystream/hydra/blob/0aeecd7a2e655ae40adca687689ff44f3df5fd9f/packages/hydra-cli/src/templates/entities/resolver.ts.mst#L119) to be queried in the form of objects. To be exact (for `ownedNftConnection` query) as:
```javascript
{
  edges: {
    node: {
      transactionalStatus: [Object],
      metadata: {},
      creatorRoyalty: {},
      transactionalStatusAuction: [Object]
    }
  }
} 
```
As seen above, 
scalar fields exists as:   `field: {}`, // emply object
while relations exist as: `field: {...having properties}`

`*Connection` resolver internally calls warthog's `findConnection` [function](https://github.com/Joystream/hydra/blob/0aeecd7a2e655ae40adca687689ff44f3df5fd9f/packages/hydra-cli/src/templates/entities/resolver.ts.mst#L138) and passes fields as an argument. `findConnection` then [transforms](https://github.com/goldcaddy77/warthog/blob/72fad57f9b5df20576286853416d60c24882e328/src/core/BaseService.ts#L148) input fields, and filters scalar ones. Then DB query is built based on filtered fields. 

Now, although **transactionalStatus** variant should exist as `{}`, it is represented as an object having different properties (of which one is `__typename`), and thus is being treated as a relation, eventually it won't be part of DB query. 

**_Solution_**: Transforming variant (removing its properties) so that it is recognized as a field and not as a relation, and eventually becomes part of DB query.