### PR TITLE
fix: processor's deterministic ids alphabet update

### DIFF
--- a/packages/hydra-processor/src/executor/TransactionalExecutor.ts
+++ b/packages/hydra-processor/src/executor/TransactionalExecutor.ts
@@ -91,11 +91,11 @@ export class EntityIdGenerator {
   private nextEntityIdPromise: Promise<string> | undefined
   private lastKnownEntityId: string | undefined
   private static lock = new AsyncLock({ maxPending: 10000 })
-  // each id is 6 chars out of 62-size alphabet, giving us 56800235584 possible ids (per entity type)
+  // each id is 8 chars out of 36-size alphabet, giving us 2821109907456 possible ids (per entity type)
   public static alphabet =
-    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+    '0123456789abcdefghijklmnopqrstuvwxyz'
 
-  public static idSize = 6
+  public static idSize = 8
 
   public static firstEntityId = Array.from(
     { length: EntityIdGenerator.idSize },

--- a/packages/hydra-processor/src/executor/TransactionalExecutor.ts
+++ b/packages/hydra-processor/src/executor/TransactionalExecutor.ts
@@ -92,8 +92,7 @@ export class EntityIdGenerator {
   private lastKnownEntityId: string | undefined
   private static lock = new AsyncLock({ maxPending: 10000 })
   // each id is 8 chars out of 36-size alphabet, giving us 2821109907456 possible ids (per entity type)
-  public static alphabet =
-    '0123456789abcdefghijklmnopqrstuvwxyz'
+  public static alphabet = '0123456789abcdefghijklmnopqrstuvwxyz'
 
   public static idSize = 8
 


### PR DESCRIPTION
Fixes issues described in https://github.com/Joystream/joystream/issues/3573

affects: @joystream/hydra-processor

These predicates are true in JS/TS:
```
const predicates = [
    '0' < 'a',
    'a' > 'A',
    'b' > 'B',
    'a' < 'b',
    'A' < 'b'
]

console.log(predicates)

// [true, true, true, true]

That means the order of characters in JS/TS is
0, 1, 2, ... , 9, A, B, C, ..., Z, a, b, c, ..., z
```

The same predicates yield different results in Postgres:
```
SELECT
    '0' < 'a',
    'a' > 'A',
    'b' > 'B',
    'a' < 'b',
    'A' < 'b',
    version(); -- let's see Postgres version

-- t, f, f, t, t, PostgreSQL 12.10 (Debian 12.10-1.pgdg110+1)

That means the order of characters in Postgres is
0, 1, 2, ... , 9, a, A, b, B, C, c ..., Z, z

Plus, when I run the same query in an online sandbox at https://extendsclass.com/postgresql-online.html
that apparently uses a different Postgres version I get different results:

-- t, t, t, t, t, PostgreSQL 11.14 (Debian 11.14-0+deb10u1)
```

Thanks to inconsistencies between Postgres character order and alphabet declared by us in JS, unexpected behavior sometimes occurred, resulting in db records overwrites.

As a bullet-proof solution, I removed upper case characters from the alphabet used by the deterministic id generator and increased the id length, so that set of possible ids is not reduced.
