### PR TITLE
fix: change property name from 'nodes' to 'node' in reslovers template file

### DIFF
--- a/packages/hydra-cli/src/templates/entities/resolver.ts.mst
+++ b/packages/hydra-cli/src/templates/entities/resolver.ts.mst
@@ -118,7 +118,7 @@ export class {{className}}Resolver {
     
     const rawFields = graphqlFields(info, {}, {});
     
-    if (rawFields.edges && rawFields.edges.nodes) {
+    if (rawFields.edges && rawFields.edges.node) {
       Object.keys(rawFields.edges.node).map((item) => {
         if (Object.keys(rawFields.edges.node[item]).includes("__typename")) {
           rawFields.edges.node[item] = {};


### PR DESCRIPTION
affects: @joystream/hydra-cli