### PR TITLE
Updated @polkadot/* dependencies, support for metadata v14

### DIFF
--- a/examples/v1/joystream-query-node/package.json
+++ b/examples/v1/joystream-query-node/package.json
@@ -32,7 +32,7 @@
   "license": "ISC",
   "dependencies": {
     "@joystream/types": "^0.14.0",
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "assert": "^2.0.0",
     "bn.js": "^5.1.2",
     "tslib": "^2.0.0"

--- a/examples/v1/subsocial-query-node/package.json
+++ b/examples/v1/subsocial-query-node/package.json
@@ -31,7 +31,7 @@
   "license": "ISC",
   "dependencies": {
     "tslib": "^2.0.0",
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "bn.js": "^5.1.2"
   },
   "devDependencies": {

--- a/examples/v2/subsocial-query-node/package.json
+++ b/examples/v2/subsocial-query-node/package.json
@@ -44,7 +44,7 @@
   "license": "ISC",
   "dependencies": {
     "tslib": "^2.0.0",
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "bn.js": "^5.1.2"
   },
   "devDependencies": {

--- a/examples/v3/kusama-query-node/package.json
+++ b/examples/v3/kusama-query-node/package.json
@@ -45,8 +45,8 @@
   "license": "ISC",
   "dependencies": {
     "tslib": "^2.0.0",
-    "@types/bn.js": "^4.11.6",
-    "bn.js": "^5.1.2"
+    "@types/bn.js": "^5.1.0",
+    "bn.js": "^5.2.1"
   },
   "devDependencies": {
     "@joystream/hydra-cli": "^3.1.0-alpha",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "is-ci": "^3.0.0",
     "lerna": "^3.22.1",
     "lint-staged": "^10.5.1",
-    "prettier": "2.0.2"
+    "prettier": "^2.7.1"
   },
   "resolutions": {
-    "@polkadot/types": "5.9.1"
+    "@polkadot/types": "8.9.1"
   },
   "lint-staged": {
     "*.ts": "yarn lint --fix"

--- a/packages/bn-typeorm/package.json
+++ b/packages/bn-typeorm/package.json
@@ -16,7 +16,7 @@
     "pub": "yarn build && yarn publish --access public",
     "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "prepack": "yarn build",
-    "lint": "eslint . --cache --ext .ts"
+    "lint": "eslint . --ext .ts"
   },
   "dependencies": {
     "bn.js": "^5.2.1",

--- a/packages/bn-typeorm/package.json
+++ b/packages/bn-typeorm/package.json
@@ -19,11 +19,11 @@
     "lint": "eslint . --cache --ext .ts"
   },
   "dependencies": {
-    "bn.js": "^5.1.3",
+    "bn.js": "^5.2.1",
     "typeorm": "https://github.com/Joystream/typeorm/releases/download/0.3.5/typeorm-v0.3.5.tgz"
   },
   "devDependencies": {
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "eslint": "^7.12.1",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",

--- a/packages/hydra-cli/package.json
+++ b/packages/hydra-cli/package.json
@@ -99,7 +99,7 @@
     "mocha": "^5",
     "mocha-chai-snapshot": "^1.0.0",
     "nyc": "^14",
-    "prettier": "^2.0.5",
+    "prettier": "^2.7.1",
     "spawn-command": "^0.0.2-1",
     "temp": "^0.9.1",
     "ts-node": "^10.2.1",

--- a/packages/hydra-cli/package.json
+++ b/packages/hydra-cli/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "rm -rf lib && yarn tsc --build tsconfig.json",
     "postpack": "rm -f oclif.manifest.json",
-    "lint": "eslint . --cache --ext .ts",
+    "lint": "eslint . --ext .ts",
     "prepack": "rm -rf lib && yarn tsc -b && cp -R ./src/templates ./lib/src/templates && oclif-dev manifest",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },

--- a/packages/hydra-cli/src/generate/model-index-context.ts
+++ b/packages/hydra-cli/src/generate/model-index-context.ts
@@ -5,36 +5,36 @@ import { withNames } from './utils'
 
 const debug = Debug('qnode-cli:model-index-context')
 
-export function withModelNames(
-  model: WarthogModel
-): { modelClasses: GeneratorContext[] } {
+export function withModelNames(model: WarthogModel): {
+  modelClasses: GeneratorContext[]
+} {
   const entities = [...model.interfaces, ...model.entities]
   return {
     modelClasses: entities.map((e) => withNames(e)),
   }
 }
 
-export function withEnumNames(
-  model: WarthogModel
-): { enums: GeneratorContext[] } {
+export function withEnumNames(model: WarthogModel): {
+  enums: GeneratorContext[]
+} {
   return { enums: model.enums.map((en) => withNames(en)) }
 }
 
-export function withUnionNames(
-  model: WarthogModel
-): { unions: GeneratorContext[] } {
+export function withUnionNames(model: WarthogModel): {
+  unions: GeneratorContext[]
+} {
   return { unions: model.unions.map((u) => withNames(u)) }
 }
 
-export function withVariantNames(
-  model: WarthogModel
-): { variants: GeneratorContext[] } {
+export function withVariantNames(model: WarthogModel): {
+  variants: GeneratorContext[]
+} {
   return { variants: model.variants.map((v: ObjectType) => withNames(v)) }
 }
 
-export function withJsonFieldNames(
-  model: WarthogModel
-): { jsonFields: GeneratorContext[] } {
+export function withJsonFieldNames(model: WarthogModel): {
+  jsonFields: GeneratorContext[]
+} {
   return { jsonFields: model.jsonFields.map((j) => withNames(j)) }
 }
 

--- a/packages/hydra-cli/src/parse/SchemaParser.ts
+++ b/packages/hydra-cli/src/parse/SchemaParser.ts
@@ -80,9 +80,8 @@ export class GraphQLSchemaParser {
         (t) => !t.name.startsWith('__') // filter out auxiliarry GraphQL types;
       ),
     ]
-    this._objectTypeDefinations = GraphQLSchemaParser.createObjectTypeDefinations(
-      this.schema
-    )
+    this._objectTypeDefinations =
+      GraphQLSchemaParser.createObjectTypeDefinations(this.schema)
   }
 
   private getUnifiedSchema(schemaPath: string): string {

--- a/packages/hydra-cli/src/templates/scaffold/mappings/package.json.mst
+++ b/packages/hydra-cli/src/templates/scaffold/mappings/package.json.mst
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@joystream/hydra-common": "{{{hydraCommonVersion}}}",
-    "@polkadot/types": "5.9.1",
+    "@polkadot/types": "8.9.1",
     "@joystream/warthog": "{{{hydraWarthogVersion}}}"
   },
   "devDependencies": {

--- a/packages/hydra-cli/src/templates/scaffold/mappings/tsconfig.json
+++ b/packages/hydra-cli/src/templates/scaffold/mappings/tsconfig.json
@@ -13,7 +13,8 @@
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "skipLibCheck": true,    
+        "skipLibCheck": true,
+        "resolveJsonModule": true
     },
     "include": ["./**/*"]
 }

--- a/packages/hydra-cli/src/templates/scaffold/package.json.mst
+++ b/packages/hydra-cli/src/templates/scaffold/package.json.mst
@@ -46,7 +46,7 @@
   "license": "ISC",
   "dependencies": {
     "tslib": "^2.0.0",
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "bn.js": "^5.1.2"
   },
   "devDependencies": {

--- a/packages/hydra-common/package.json
+++ b/packages/hydra-common/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "pub": "yarn build && yarn publish --access public",
     "build": "rm -rf lib && yarn tsc --build tsconfig.json",
-    "lint": "eslint . --cache --ext .ts",
+    "lint": "eslint . --ext .ts",
     "prepack": "yarn build",
     "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only \"src/**/*.test.ts\""
   },

--- a/packages/hydra-common/package.json
+++ b/packages/hydra-common/package.json
@@ -20,10 +20,10 @@
     "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "bn.js": "^5.1.3"
+    "bn.js": "^5.2.1"
   },
   "devDependencies": {
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.5",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",

--- a/packages/hydra-db-utils/package.json
+++ b/packages/hydra-db-utils/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "pub": "yarn build && yarn publish --access public",
     "build": "rm -rf lib && yarn tsc --build tsconfig.json",
-    "lint": "eslint . --cache --ext .ts",
+    "lint": "eslint . --ext .ts",
     "prepack": "yarn build",
     "test": "nyc --extension .ts mocha --timeout 50000 --require ts-node/register --forbid-only \"test/**/*.test.ts\""
   },

--- a/packages/hydra-db-utils/package.json
+++ b/packages/hydra-db-utils/package.json
@@ -21,13 +21,13 @@
   "dependencies": {
     "@joystream/hydra-common": "^3.1.0-alpha.27",
     "@types/ioredis": "^4.17.4",
-    "bn.js": "^5.1.3",
+    "bn.js": "^5.2.1",
     "ioredis": "^4.17.3",
     "lodash": "^4.17.20",
     "typeorm": "https://github.com/Joystream/typeorm/releases/download/0.3.5/typeorm-v0.3.5.tgz"
   },
   "devDependencies": {
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "ts-node": "^10.2.1",

--- a/packages/hydra-db-utils/src/db/SnakeNamingStrategy.ts
+++ b/packages/hydra-db-utils/src/db/SnakeNamingStrategy.ts
@@ -7,8 +7,10 @@
 import { DefaultNamingStrategy, NamingStrategyInterface } from 'typeorm'
 import { snakeCase } from 'typeorm/util/StringUtils'
 
-export class SnakeNamingStrategy extends DefaultNamingStrategy
-  implements NamingStrategyInterface {
+export class SnakeNamingStrategy
+  extends DefaultNamingStrategy
+  implements NamingStrategyInterface
+{
   constructor() {
     super()
   }

--- a/packages/hydra-e2e-tests/fixtures/mappings/mappings.ts
+++ b/packages/hydra-e2e-tests/fixtures/mappings/mappings.ts
@@ -26,7 +26,7 @@ async function getOrCreate<T>(
   store: DatabaseManager
 ): Promise<T> {
   let entity: T | undefined = await store.get<T>(E, {
-    where: ({ id } as unknown) as FindOptionsWhere<T>,
+    where: { id } as unknown as FindOptionsWhere<T>,
   })
 
   if (entity === undefined) {

--- a/packages/hydra-e2e-tests/package.json
+++ b/packages/hydra-e2e-tests/package.json
@@ -22,8 +22,8 @@
     "e2e-test": "bash run-tests.sh"
   },
   "dependencies": {
-    "@polkadot/api": "5.9.1",
-    "@polkadot/keyring": "7.9.2",
+    "@polkadot/api": "8.9.1",
+    "@polkadot/keyring": "9.5.1",
     "fetch": "^1.1.0",
     "graphql-request": "^3.3.0",
     "graphql-subscriptions-client": "^0.16.0",
@@ -39,7 +39,7 @@
     "eslint": "^7.11.0",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "prettier": "^2.1.2",
+    "prettier": "^2.7.1",
     "ts-node": "^10.2.1",
     "typescript": "4.4.2"
   }

--- a/packages/hydra-e2e-tests/package.json
+++ b/packages/hydra-e2e-tests/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint . --cache --ext .ts --config .eslintrc.js",
+    "lint": "eslint . --ext .ts --config .eslintrc.js",
     "build": "tsc --build tsconfig.json",
     "docker:build": "docker build ./schema -t hydra:${CLITAG:-latest} --no-cache",
     "db:migrate": "bash ./scripts/db.sh --db-name indexer-db --db-host db up  && bash ./scripts/db.sh --db-name processor-db --db-host db up",

--- a/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
+++ b/packages/hydra-e2e-tests/test/e2e/api/processor-api.ts
@@ -142,9 +142,11 @@ export function subscribeToProcessorStatus(): void {
     .subscribe({
       next({ data }: unknown) {
         if (data) {
-          processorStatus = (data as {
-            stateSubscription: ProcessorStatus
-          }).stateSubscription
+          processorStatus = (
+            data as {
+              stateSubscription: ProcessorStatus
+            }
+          ).stateSubscription
         }
       },
     })

--- a/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
+++ b/packages/hydra-e2e-tests/test/e2e/transfer-e2e.test.ts
@@ -82,12 +82,8 @@ describe('end-to-end transfer tests', () => {
   })
 
   it('fetch datetime field from transfer', async () => {
-    const {
-      insertedAt,
-      createdAt,
-      updatedAt,
-      timestamp,
-    } = await fetchDateTimeFieldFromTransfer()
+    const { insertedAt, createdAt, updatedAt, timestamp } =
+      await fetchDateTimeFieldFromTransfer()
     const ts = Number.parseInt(timestamp)
 
     console.log(`Timestamp: ${timestamp}, ts: ${ts}`)

--- a/packages/hydra-indexer-gateway/package.json
+++ b/packages/hydra-indexer-gateway/package.json
@@ -46,7 +46,7 @@
     "@joystream/hydra-db-utils": "^3.1.0-alpha.27",
     "@joystream/warthog": "^2.41.5",
     "@types/ioredis": "^4.17.4",
-    "bn.js": "^5.1.3",
+    "bn.js": "^5.2.1",
     "dotenv": "^8.2.0",
     "graphql-parse-resolve-info": "^4.9.0",
     "graphql-redis-subscriptions": "^2.3.1",
@@ -56,7 +56,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "@types/graphql": "^14.5.0",
     "@types/ioredis": "^4.17.4",
     "@types/jest": "^24.0.23",

--- a/packages/hydra-indexer/package.json
+++ b/packages/hydra-indexer/package.json
@@ -19,7 +19,7 @@
     "docker:tag": "docker tag hydra-indexer:latest joystream/hydra-indexer:v${VERSION_TAG} && docker tag hydra-indexer:latest joystream/hydra-indexer:${MAJOR_VERSION_TAG} && docker tag hydra-indexer:latest joystream/hydra-indexer:${RELEASE_TAG:-next}",
     "docker:publish": "export VERSION_TAG=$(node -p 'require(\"./package.json\").version') && export MAJOR_VERSION_TAG=$(echo $VERSION_TAG|cut -d'.' -f1) && yarn docker:build && yarn docker:tag && docker push joystream/hydra-indexer --all-tags",
     "build": "rm -rf lib && yarn tsc --build tsconfig.json",
-    "lint": "eslint . --cache --ext .ts",
+    "lint": "eslint . --ext .ts",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js",
     "i-test": "docker-compose -f docker-compose-test.yml up -d && sh ./run-integration-tests.sh",
     "post-i-test": "docker-compose -f docker-compose-test.yml down",

--- a/packages/hydra-indexer/package.json
+++ b/packages/hydra-indexer/package.json
@@ -39,11 +39,11 @@
     "@joystream/bn-typeorm": "^3.1.0-alpha.27",
     "@joystream/hydra-common": "^3.1.0-alpha.27",
     "@joystream/hydra-db-utils": "^3.1.0-alpha.27",
-    "@polkadot/api": "5.9.1",
+    "@polkadot/api": "8.9.1",
     "@types/express": "^4.17.8",
     "@types/ioredis": "^4.17.4",
     "@types/lodash": "^4.14.161",
-    "bn.js": "^5.1.2",
+    "bn.js": "^5.2.1",
     "commander": "^6.2.0",
     "debug": "^4.1.1",
     "delay": "~5.0.0",
@@ -72,8 +72,7 @@
     "util": "^0.12.3"
   },
   "devDependencies": {
-    "@polkadot/ts": "^0.3.14",
-    "@types/bn.js": "^4.11.6",
+    "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.2.12",
     "@types/debug": "^4.1.5",
     "@types/figlet": "^1.2.1",
@@ -91,7 +90,7 @@
     "eslint": "^7.1.0",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "prettier": "^2.1.2",
+    "prettier": "^2.7.1",
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.2.1",
     "typescript": "4.4.2"

--- a/packages/hydra-indexer/src/entities/SubstrateBlockEntity.ts
+++ b/packages/hydra-indexer/src/entities/SubstrateBlockEntity.ts
@@ -15,8 +15,10 @@ import { AbstractWarthogModel } from './AbstractWarthogModel'
 @Entity({
   name: 'substrate_block',
 })
-export class SubstrateBlockEntity extends AbstractWarthogModel
-  implements SubstrateBlock {
+export class SubstrateBlockEntity
+  extends AbstractWarthogModel
+  implements SubstrateBlock
+{
   @PrimaryColumn()
   id!: string
 

--- a/packages/hydra-indexer/src/entities/SubstrateEventEntity.ts
+++ b/packages/hydra-indexer/src/entities/SubstrateEventEntity.ts
@@ -26,8 +26,10 @@ export const EVENT_TABLE_NAME = 'substrate_event'
 @Entity({
   name: EVENT_TABLE_NAME,
 })
-export class SubstrateEventEntity extends AbstractWarthogModel
-  implements SubstrateEvent {
+export class SubstrateEventEntity
+  extends AbstractWarthogModel
+  implements SubstrateEvent
+{
   @PrimaryColumn()
   id!: string
 

--- a/packages/hydra-indexer/src/entities/SubstrateExtrinsicEntity.ts
+++ b/packages/hydra-indexer/src/entities/SubstrateExtrinsicEntity.ts
@@ -28,8 +28,10 @@ export const EXTRINSIC_TABLE_NAME = 'substrate_extrinsic'
 @Entity({
   name: EXTRINSIC_TABLE_NAME,
 })
-export class SubstrateExtrinsicEntity extends AbstractWarthogModel
-  implements SubstrateExtrinsic {
+export class SubstrateExtrinsicEntity
+  extends AbstractWarthogModel
+  implements SubstrateExtrinsic
+{
   @PrimaryColumn()
   id!: string
 

--- a/packages/hydra-indexer/src/indexer/IndexBuilder.ts
+++ b/packages/hydra-indexer/src/indexer/IndexBuilder.ts
@@ -126,14 +126,14 @@ export class IndexBuilder {
         signedBlock: { block },
       } = blockData
 
-      const extrinsicEntities: SubstrateExtrinsicEntity[] = block.extrinsics.map(
-        (e, index) =>
+      const extrinsicEntities: SubstrateExtrinsicEntity[] =
+        block.extrinsics.map((e, index) =>
           fromBlockExtrinsic({
             e,
             blockEntity,
             indexInBlock: index,
           })
-      )
+        )
       await em.save(extrinsicEntities)
       debug(`Saved ${extrinsicEntities.length} extrinsics`)
 

--- a/packages/hydra-indexer/src/node/config.ts
+++ b/packages/hydra-indexer/src/node/config.ts
@@ -166,8 +166,7 @@ export function configure(): void {
       // Number of time the worker tries to fetch a block
       BLOCK_PRODUCER_FETCH_RETRIES: num({
         default: 3,
-        desc:
-          'Number of times a worker retries to fetch a block before giving up',
+        desc: 'Number of times a worker retries to fetch a block before giving up',
       }),
 
       // Timeout (in milliseconds) for each API call
@@ -178,8 +177,7 @@ export function configure(): void {
       // Number of times an API call is retried before giving up and throwing and error
       SUBSTRATE_API_CALL_RETRIES: num({
         default: 5,
-        desc:
-          'Number of times an API call is retried before giving up and throwing and error',
+        desc: 'Number of times an API call is retried before giving up and throwing and error',
       }),
 
       // If the block producer does not recieve a new block within this time limit,

--- a/packages/hydra-indexer/src/substrate/SubstrateService.ts
+++ b/packages/hydra-indexer/src/substrate/SubstrateService.ts
@@ -1,3 +1,5 @@
+import '@polkadot/api-augment/substrate'
+
 import {
   Hash,
   Header,

--- a/packages/hydra-indexer/test/fixtures/mock-factory.ts
+++ b/packages/hydra-indexer/test/fixtures/mock-factory.ts
@@ -4,9 +4,9 @@ import { BlockPayload } from '../../src/model'
 import { withTs } from '@joystream/hydra-common'
 
 export function blockPayload(height: number): BlockPayload {
-  return (withTs({
+  return withTs({
     height,
-  }) as unknown) as BlockPayload
+  }) as unknown as BlockPayload
 }
 
 export function queryEventBlock(block = 0): QueryEventBlock {
@@ -28,18 +28,18 @@ export function* queryEvent(
   let i = 0
   do {
     yield {
-      eventRecord: ({
-        phase: ({
+      eventRecord: {
+        phase: {
           toJSON: () => {
             return {}
           },
-        } as unknown) as Phase,
-        event: ({
+        } as unknown as Phase,
+        event: {
           method: 'fake.method',
           section: 'fake.section',
           data: [],
-        } as unknown) as Event,
-      } as unknown) as EventRecord,
+        } as unknown as Event,
+      } as unknown as EventRecord,
       blockNumber: block,
       blockTimestamp: 11111111111,
       indexInBlock: i,

--- a/packages/hydra-indexer/test/integration/status-service.test.ts
+++ b/packages/hydra-indexer/test/integration/status-service.test.ts
@@ -19,8 +19,10 @@ dotenv.config({ path: './test/.env' })
 const debug = Debug('index-builder:status-service-test')
 const FINAL_CHAIN_HEIGHT = 7
 
-class MockBlockProducer extends EventEmitter
-  implements IBlockProducer<QueryEventBlock> {
+class MockBlockProducer
+  extends EventEmitter
+  implements IBlockProducer<QueryEventBlock>
+{
   private height = 0
 
   async fetchBlock(height: number): Promise<QueryEventBlock> {
@@ -104,9 +106,8 @@ describe('IndexerStatusService', () => {
     )
     await sleep(300)
 
-    const redisClient = Container.get<RedisClientFactory>(
-      'RedisClientFactory'
-    ).getClient()
+    const redisClient =
+      Container.get<RedisClientFactory>('RedisClientFactory').getClient()
     const totalEventsVal = (await redisClient.hget(EVENT_TOTAL, 'ALL')) || '0'
     const totalEvents = Number.parseInt(totalEventsVal)
     // we start with heigh 0, so FINAL_CHAIN_HEIGHT + 1 blocks in total

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -32,7 +32,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "test-build": "rm -rf test-lib && yarn tsc --build ./test/tsconfig.json",
     "prepack": "yarn build && oclif-dev manifest",
-    "lint": "eslint . --cache --ext .ts",
+    "lint": "eslint . --ext .ts",
     "test": "bash run-tests.sh",
     "test:run": "yarn nyc --extension .ts mocha --timeout 70000 --require ts-node/register --forbid-only \"./{src,test}/**/*.spec.ts\""
   },

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -43,7 +43,7 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
     "async-lock": "^1.3.1",
-    "bn.js": "^5.2.0",
+    "bn.js": "^5.2.1",
     "chalk": "^4.1.0",
     "delay": "^5.0.0",
     "dotenv": "^8.2.0",
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@joystream/hydra-cli": "^3.1.0-alpha.27",
-    "@polkadot/api": "5.9.1",
+    "@polkadot/api": "8.9.1",
     "@types/async-lock": "^1.1.3",
     "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.2.19",

--- a/packages/hydra-processor/src/executor/TransactionalExecutor.ts
+++ b/packages/hydra-processor/src/executor/TransactionalExecutor.ts
@@ -239,9 +239,11 @@ async function fillRequiredWarthogFields<T extends Record<string, unknown>>(
 
   // eslint-disable-next-line no-prototype-builtins
   if (!entity.hasOwnProperty('id')) {
-    const entityClass = ((entity as unknown) as {
-      constructor: ObjectType<{ id: string }>
-    }).constructor
+    const entityClass = (
+      entity as unknown as {
+        constructor: ObjectType<{ id: string }>
+      }
+    ).constructor
 
     if (!entityIdGenerators.has(entityClass.name)) {
       entityIdGenerators.set(

--- a/packages/hydra-processor/src/ingest/GraphQLSource.ts
+++ b/packages/hydra-processor/src/ingest/GraphQLSource.ts
@@ -18,13 +18,11 @@ const debug = Debug('hydra-processor:graphql-source')
 
 type SubstrateType = SubstrateBlock | SubstrateEvent | SubstrateExtrinsic
 
-const REVIVE_SUBSTRATE_FIELDS: Partial<
-  {
-    [P in keyof SubstrateType]: SubstrateType[P] extends number | BigInt
-      ? 'BigInt' | 'Number'
-      : never
-  }
-> = {
+const REVIVE_SUBSTRATE_FIELDS: Partial<{
+  [P in keyof SubstrateType]: SubstrateType[P] extends number | BigInt
+    ? 'BigInt' | 'Number'
+    : never
+}> = {
   'timestamp': 'Number',
   'tip': 'BigInt',
   'blockTimestamp': 'Number',
@@ -67,11 +65,9 @@ export class GraphQLSource implements IProcessorSource {
     return status.indexerStatus as IndexerStatus
   }
 
-  async nextBatch<T>(
-    queries: {
-      [K in keyof T]: IndexerQuery
-    }
-  ): Promise<{ [K in keyof typeof queries]: SubstrateEvent[] }> {
+  async nextBatch<T>(queries: {
+    [K in keyof T]: IndexerQuery
+  }): Promise<{ [K in keyof typeof queries]: SubstrateEvent[] }> {
     const query = collectQueries(queries)
     if (conf().VERBOSE) debug(`GraphqQL Query: ${query}`)
 
@@ -79,9 +75,9 @@ export class GraphQLSource implements IProcessorSource {
     //   { [K in keyof typeof queries]: SubstrateEvent[] }
     // >(query)
 
-    const raw = await this.requestSubstrateData<
-      { [K in keyof typeof queries]: SubstrateEvent[] }
-    >(query)
+    const raw = await this.requestSubstrateData<{
+      [K in keyof typeof queries]: SubstrateEvent[]
+    }>(query)
 
     debug(
       `Fetched ${Object.keys(raw).reduce(
@@ -97,18 +93,16 @@ export class GraphQLSource implements IProcessorSource {
     }
   }
 
-  executeQueries<T>(
-    queries: {
-      [K in keyof T]: GraphQLQuery<T[K]>
-    }
-  ): Promise<{ [K in keyof T]: (T[K] & AsJson<T[K]>)[] }> {
+  executeQueries<T>(queries: {
+    [K in keyof T]: GraphQLQuery<T[K]>
+  }): Promise<{ [K in keyof T]: (T[K] & AsJson<T[K]>)[] }> {
     const bigNamedQuery = collectNamedQueries(queries)
     // return this.graphClient.request<
     //   { [K in keyof T]: (T[K] & AsJson<T[K]>)[] }
     // >(bigNamedQuery)
-    return this.requestSubstrateData<
-      { [K in keyof T]: (T[K] & AsJson<T[K]>)[] }
-    >(bigNamedQuery)
+    return this.requestSubstrateData<{
+      [K in keyof T]: (T[K] & AsJson<T[K]>)[]
+    }>(bigNamedQuery)
   }
 
   async getBlock(blockNumber: number): Promise<SubstrateBlock> {
@@ -176,13 +170,9 @@ export class GraphQLSource implements IProcessorSource {
 
   private async request<T, K>(
     query: string,
-    revive: Partial<
-      {
-        [P in keyof K]: K[P] extends number | BigInt
-          ? 'BigInt' | 'Number'
-          : never
-      }
-    >
+    revive: Partial<{
+      [P in keyof K]: K[P] extends number | BigInt ? 'BigInt' | 'Number' : never
+    }>
   ): Promise<T> {
     const raw = await this.graphClient.request<T>(query)
     return JSON.parse(JSON.stringify(raw), (k, v) => {

--- a/packages/hydra-processor/src/ingest/IProcessorSource.ts
+++ b/packages/hydra-processor/src/ingest/IProcessorSource.ts
@@ -58,11 +58,9 @@ export interface ArrayFilter<T extends readonly unknown[]> {
   none: ArrayFilterValue<T>
 }
 
-export type ObjectFilter<T> = Partial<
-  {
-    [P in keyof T]: Partial<TypedFilter<T[P]>>
-  }
->
+export type ObjectFilter<T> = Partial<{
+  [P in keyof T]: Partial<TypedFilter<T[P]>>
+}>
 
 export interface QueryFilter<T> {
   where: ObjectFilter<T>
@@ -74,19 +72,16 @@ export interface QueryFilter<T> {
 }
 
 // extract T from type of Array<T>
-export type ArrayElement<
-  ArrayType extends readonly unknown[]
-> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never
+export type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never
 
 export type QueryField<T> =
   | keyof T
-  | Partial<
-      {
-        [P in keyof T]: QueryFields<
-          T[P] extends readonly unknown[] ? ArrayElement<T[P]> : T[P]
-        >
-      }
-    >
+  | Partial<{
+      [P in keyof T]: QueryFields<
+        T[P] extends readonly unknown[] ? ArrayElement<T[P]> : T[P]
+      >
+    }>
 
 export type AsJson<T> = T extends
   | string
@@ -124,17 +119,13 @@ export interface GraphQLQuery<T> {
 }
 
 export interface IProcessorSource {
-  nextBatch<T>(
-    queries: {
-      [K in keyof T]: IndexerQuery
-    }
-  ): Promise<{ [K in keyof typeof queries]: SubstrateEvent[] }>
+  nextBatch<T>(queries: {
+    [K in keyof T]: IndexerQuery
+  }): Promise<{ [K in keyof typeof queries]: SubstrateEvent[] }>
 
-  executeQueries<T>(
-    queries: {
-      [K in keyof T]: GraphQLQuery<T[K]>
-    }
-  ): Promise<{ [K in keyof T]: (T[K] & AsJson<T[K]>)[] }>
+  executeQueries<T>(queries: {
+    [K in keyof T]: GraphQLQuery<T[K]>
+  }): Promise<{ [K in keyof T]: (T[K] & AsJson<T[K]>)[] }>
 
   getIndexerStatus(): Promise<IndexerStatus>
 

--- a/packages/hydra-processor/src/ingest/graphql-query-builder.ts
+++ b/packages/hydra-processor/src/ingest/graphql-query-builder.ts
@@ -114,9 +114,9 @@ export function buildQueryFields<T>(fields: QueryFields<T>): string {
         )
       }
       const key = keys[0] as keyof T
-      const nestedFields = (field as Partial<
-        { [P in keyof T]: QueryFields<T[P]> }
-      >)[key] as QueryFields<T[typeof key]>
+      const nestedFields = (
+        field as Partial<{ [P in keyof T]: QueryFields<T[P]> }>
+      )[key] as QueryFields<T[typeof key]>
 
       output = `
       ${output}${key} {
@@ -166,17 +166,15 @@ export function buildQuery<T>({
   }`)
 }
 
-export function collectNamedQueries<T>(
-  queries: {
-    [K in keyof T]: GraphQLQuery<T[K]>
-  }
-): string {
+export function collectNamedQueries<T>(queries: {
+  [K in keyof T]: GraphQLQuery<T[K]>
+}): string {
   return `query {
     ${Object.keys(queries)
       .map((name) => {
-        const query = queries[name as keyof typeof queries] as GraphQLQuery<
-          unknown
-        >
+        const query = queries[
+          name as keyof typeof queries
+        ] as GraphQLQuery<unknown>
         return `${name}: ${buildQuery(query)}`
       })
       .join('\n')}

--- a/packages/hydra-processor/src/queue/BlockQueue.spec.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.spec.ts
@@ -8,23 +8,23 @@ import { getConfig as conf } from '../start/config'
 describe('EventQueue', () => {
   it('should properly set the initial filter', () => {
     const eventQueue: BlockQueue = new BlockQueue()
-    eventQueue.stateKeeper = ({
+    eventQueue.stateKeeper = {
       getState: () => {
         return {
           lastScannedBlock: 1000,
           lastProcessedEvent: formatEventId(0, 5),
         } as IProcessorState
       },
-    } as unknown) as IStateKeeper
+    } as unknown as IStateKeeper
 
-    eventQueue.indexerStatus = ({ head: 10000 } as unknown) as IndexerStatus
-    eventQueue.mappingFilter = ({
+    eventQueue.indexerStatus = { head: 10000 } as unknown as IndexerStatus
+    eventQueue.mappingFilter = {
       events: [],
       extrinsics: [],
       range: {
         to: 150000,
       },
-    } as unknown) as MappingFilter
+    } as unknown as MappingFilter
 
     const initFilter = eventQueue.getInitialRange()
 
@@ -41,20 +41,20 @@ describe('EventQueue', () => {
   it('should update the next block range', () => {
     const eventQueue: BlockQueue = new BlockQueue()
 
-    eventQueue.rangeFilter = ({
+    eventQueue.rangeFilter = {
       block: {
         gt: 0,
         lte: 100000,
       },
-    } as unknown) as RangeFilter
+    } as unknown as RangeFilter
 
-    eventQueue.mappingFilter = ({
+    eventQueue.mappingFilter = {
       range: {
         to: 150000,
       },
-    } as unknown) as MappingFilter
+    } as unknown as MappingFilter
 
-    eventQueue.indexerStatus = ({ head: 500000 } as unknown) as IndexerStatus
+    eventQueue.indexerStatus = { head: 500000 } as unknown as IndexerStatus
 
     const next = eventQueue.nextBlockRange(eventQueue.rangeFilter.block)
     expect(next.gt).equals(100000, 'should update the lower block limit')

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -348,9 +348,9 @@ export function sortAndTrim(
   return mappingData
 }
 
-export function prepareIndexerQueries(
-  filter: MappingFilter
-): { [key in Kind]?: Partial<IndexerQuery> } {
+export function prepareIndexerQueries(filter: MappingFilter): {
+  [key in Kind]?: Partial<IndexerQuery>
+} {
   const { events, extrinsics } = filter
   const queries: { [key in Kind]?: Partial<IndexerQuery> } = {}
 

--- a/packages/hydra-processor/src/util/utils.ts
+++ b/packages/hydra-processor/src/util/utils.ts
@@ -1,6 +1,8 @@
-export function parseEventId(
-  eventId: string
-): { blockHeight: number; eventId: number; hash?: string } {
+export function parseEventId(eventId: string): {
+  blockHeight: number
+  eventId: number
+  hash?: string
+} {
   const parts = eventId.split('-')
 
   if (parts.length < 2) {

--- a/packages/hydra-typegen/package.json
+++ b/packages/hydra-typegen/package.json
@@ -24,7 +24,7 @@
     "build": "yarn clean && yarn tsc && yarn copy-templates",
     "run-dev": "node ./bin/run",
     "postpack": "rm -f oclif.manifest.json",
-    "lint": "eslint . --cache --ext .ts",
+    "lint": "eslint . --ext .ts",
     "prepack": "yarn build && oclif-dev manifest",
     "test": "nyc --extension .ts mocha --require ts-node/register --forbid-only \"./{src,test}/**/*.spec.ts\""
   },

--- a/packages/hydra-typegen/package.json
+++ b/packages/hydra-typegen/package.json
@@ -41,7 +41,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
-    "@polkadot/api": "5.9.1",
+    "@polkadot/api": "8.9.1",
     "debug": "^4.3.1",
     "figlet": "^1.5.2",
     "handlebars": "^4.7.6",

--- a/packages/hydra-typegen/src/config/parse-yaml.ts
+++ b/packages/hydra-typegen/src/config/parse-yaml.ts
@@ -12,10 +12,6 @@ const options = {
         source: 'string',
         'blockHash?': 'string',
       },
-      'customTypes?': {
-        lib: 'string',
-        typedefsLoc: 'string',
-      },
       'events?': ['string'],
       'calls?': ['string'],
       outDir: 'string',

--- a/packages/hydra-typegen/src/config/validate.ts
+++ b/packages/hydra-typegen/src/config/validate.ts
@@ -1,23 +1,9 @@
-import path from 'path'
-import fs from 'fs'
 import { IConfig } from '../commands/typegen'
 
-export function validate({ events, calls, customTypes }: IConfig): void {
+export function validate({ events, calls }: IConfig): void {
   if (events.length === 0 && calls.length === 0) {
     throw new Error(
       `Nothing to generate: at least one event or call should be provided.`
     )
-  }
-
-  if (customTypes) {
-    if (customTypes.typedefsLoc === undefined) {
-      throw new Error(
-        `Missing the type defintion location for the custom for types. Did you forget to add typedefsLoc?`
-      )
-    }
-    const typedefsPath = path.resolve(customTypes.typedefsLoc)
-    if (!fs.existsSync(typedefsPath)) {
-      throw new Error(`Cannot find type definition file at ${typedefsPath}`)
-    }
   }
 }

--- a/packages/hydra-typegen/src/generators/gen-index.ts
+++ b/packages/hydra-typegen/src/generators/gen-index.ts
@@ -10,20 +10,18 @@ const generateIndexTemplate = handlebars.compile(readTemplate('index'))
 
 export function generateIndex({
   modules,
-  customTypes,
+  originalMetadata,
   dest,
 }: GeneratorConfig): void {
-  if (customTypes) {
-    const typedefsPath = path.resolve(customTypes.typedefsLoc)
-    fs.copyFileSync(typedefsPath, path.join(dest, `typedefs.json`))
-  }
+  fs.writeFileSync(
+    path.join(dest, `metadata.json`),
+    JSON.stringify(originalMetadata.toHex())
+  )
 
   writeFile(path.join(dest, `index.ts`), () =>
     formatWithPrettier(
       generateIndexTemplate({
         modules: modules.map((m) => m.module),
-        hasTypeDefs:
-          customTypes !== undefined && customTypes.typedefsLoc !== undefined,
       })
     )
   )

--- a/packages/hydra-typegen/src/generators/gen-modules.ts
+++ b/packages/hydra-typegen/src/generators/gen-modules.ts
@@ -1,14 +1,20 @@
-import { ModuleMeta } from '../metadata'
+import { ExtractedModuleMeta } from '../metadata'
 import { formatWithPrettier, readTemplate, writeFile } from '../util'
 import path from 'path'
 import { buildModuleImports } from './imports'
 import { GeneratorConfig } from '.'
 import { handlebars } from './helpers'
 import { kebabCase } from 'lodash'
+import { ImportsDef } from './types'
 
 const debug = require('debug')('hydra-typegen:gen-modules')
 
 const generateModuleTemplate = handlebars.compile(readTemplate('module'))
+
+type ModuleTemplateProps = {
+  validateArgs: boolean
+  imports: ImportsDef
+} & ExtractedModuleMeta
 
 export function generateModuleTypes(config: GeneratorConfig): void {
   const { modules, dest } = config
@@ -23,9 +29,9 @@ export function generateModuleTypes(config: GeneratorConfig): void {
 }
 
 export function buildModuleProps(
-  meta: ModuleMeta,
+  meta: ExtractedModuleMeta,
   config: GeneratorConfig
-): unknown {
+): ModuleTemplateProps {
   const { validateArgs } = config
   const imports = buildModuleImports(meta, config)
 

--- a/packages/hydra-typegen/src/generators/helpers.spec.ts
+++ b/packages/hydra-typegen/src/generators/helpers.spec.ts
@@ -5,21 +5,25 @@ import { compact as c } from '../util'
 describe('helpers', () => {
   it('should render return type ', () => {
     const prmsReturn = helper.paramsReturnType.bind({
-      args: ['Type1', 'Type2 & Codec', 'Option<Type3>'],
+      params: [
+        { type: 'Type1' },
+        { type: 'Type2 & Codec' },
+        { type: 'Option<Type3>' },
+      ],
     })
     expect(c(prmsReturn())).to.equal(c(`[Type1, Type2 & Codec, Option<Type3>]`))
   })
 
   it('should render return type with tupes ', () => {
     const prmsReturn = helper.paramsReturnType.bind({
-      args: ['Type1', 'Vec<(Type1,Type2)>'],
+      params: [{ type: 'Type1' }, { type: 'Vec<(Type1,Type2)>' }],
     })
     expect(c(prmsReturn())).to.equal(c(`[Type1, Vec<[Type1,Type2] & Codec>]`))
   })
 
   it('should render return type statement', () => {
     const prmsReturnStmt = helper.paramsReturnStmt.bind({
-      args: ['Type1', 'Type2 & Balance'],
+      params: [{ type: 'Type1' }, { type: 'Type2 & Balance' }],
     })
     expect(c(prmsReturnStmt())).to.equal(
       c(`return [createTypeUnsafe(typeRegistry, 'Type1', [this.ctx.params[0].value]), 
@@ -29,7 +33,7 @@ describe('helpers', () => {
 
   it('should handle tuple types', () => {
     const prmsReturnStmt = helper.paramsReturnStmt.bind({
-      args: ['Vec<(Type1,Type2,(Balance1,Balance2))>'],
+      params: [{ type: 'Vec<(Type1,Type2,(Balance1,Balance2))>' }],
     })
     expect(c(prmsReturnStmt())).to.equal(
       c(

--- a/packages/hydra-typegen/src/generators/imports-registry.ts
+++ b/packages/hydra-typegen/src/generators/imports-registry.ts
@@ -1,8 +1,6 @@
 import { ImportsRegistry } from './types'
-import { CustomTypes } from '../commands/typegen'
 import { warn } from '../log'
 import { builtInClasses, builtInInterfaceDefs } from '../metadata/default-types'
-import { registerCustomTypes } from '../metadata'
 
 const debug = require('debug')('hydra-typegen:imports-registry')
 
@@ -29,9 +27,7 @@ const METADATA = ['Metadata']
 const LOCAL = ['typeRegistry']
 const HYDRA_COMMON = ['substrate']
 
-export function buildImportsRegistry(
-  customTypes: CustomTypes | undefined
-): ImportsRegistry {
+export function buildImportsRegistry(): ImportsRegistry {
   const importsRegistry = {}
   // add primitive classes
   const typeClasses = builtInClasses.filter((name) => !NO_CODEC.includes(name))
@@ -63,10 +59,6 @@ export function buildImportsRegistry(
   }
 
   addPolkadotInterfaces(importsRegistry)
-  // this goes last so that it overrides all previous definitions
-  if (customTypes) {
-    addCustomTypes(importsRegistry, customTypes)
-  }
 
   return importsRegistry
 }
@@ -81,23 +73,5 @@ function addPolkadotInterfaces(importsRegistry: ImportsRegistry) {
       }
       importsRegistry[type] = KNOWN_LOCATIONS.interfaces
     })
-  })
-}
-
-function addCustomTypes(
-  importsRegistry: ImportsRegistry,
-  customTypes: CustomTypes
-) {
-  const { lib, typedefsLoc } = customTypes
-
-  const defs = registerCustomTypes(typedefsLoc)
-
-  Object.keys(defs).forEach((type) => {
-    if (importsRegistry[type]) {
-      warn(
-        `Overwriting duplicated type '${type}' ${importsRegistry[type]} -> ${lib}`
-      )
-    }
-    importsRegistry[type] = lib
   })
 }

--- a/packages/hydra-typegen/src/generators/imports.ts
+++ b/packages/hydra-typegen/src/generators/imports.ts
@@ -1,20 +1,19 @@
 import { GeneratorConfig, ImportsDef } from './types'
-import { ModuleMeta } from '../metadata'
+import { ExtractedModuleMeta } from '../metadata'
 
 export function buildModuleImports(
-  { types }: ModuleMeta,
+  { types }: ExtractedModuleMeta,
   { importsRegistry }: GeneratorConfig
 ): ImportsDef {
   const importsDef: ImportsDef = {}
 
   types.forEach((i) => {
-    if (importsRegistry[i] === undefined) {
-      throw new Error(`Cannot resolve import for type ${i}`)
+    const importLoc = importsRegistry[i] || '@polkadot/types/lookup'
+
+    if (!importsDef[importLoc]) {
+      importsDef[importLoc] = {}
     }
-    if (!importsDef[importsRegistry[i]]) {
-      importsDef[importsRegistry[i]] = {}
-    }
-    importsDef[importsRegistry[i]][i] = true
+    importsDef[importLoc][i] = true
   })
 
   return importsDef

--- a/packages/hydra-typegen/src/generators/types.ts
+++ b/packages/hydra-typegen/src/generators/types.ts
@@ -1,11 +1,11 @@
-import { ModuleMeta } from '../metadata'
-import { CustomTypes } from '../commands/typegen'
+import { ExtractedModuleMeta } from '../metadata'
+import { Metadata } from '@polkadot/types/metadata'
 
 export type GeneratorConfig = {
-  modules: ModuleMeta[]
+  modules: ExtractedModuleMeta[]
   importsRegistry: ImportsRegistry
+  originalMetadata: Metadata
   dest: string
-  customTypes?: CustomTypes
   validateArgs: boolean
 }
 

--- a/packages/hydra-typegen/src/metadata/events.spec.ts
+++ b/packages/hydra-typegen/src/metadata/events.spec.ts
@@ -1,26 +1,312 @@
-import { stripTypes } from './extract'
+import { extractTypesFromVariant } from './extract'
+import { SiType } from '@polkadot/types/interfaces/scaleInfo'
 import { expect } from 'chai'
+import { TypeRegistry } from '@polkadot/types'
 
 describe('events', () => {
   it('should parse arg types', () => {
-    const argTypes = [
-      'Vec<u32>',
-      'AccountId & Codec',
-      'Balance | LookupSource<Balance>',
-      'Vec<(CategoryId,ThreadId,PostId,bool)>',
-    ]
-    const types = stripTypes(argTypes)
-    console.log(types.join(','))
+    const registry = new TypeRegistry()
+    const meta = registry.createType('Metadata', {
+      'metadata': {
+        'v14': {
+          'lookup': {
+            'types': [
+              {
+                'id': 0,
+                'type': {
+                  'path': ['sp_core', 'crypto', 'AccountId32'],
+                  'params': [],
+                  'def': {
+                    'composite': {
+                      'fields': [
+                        {
+                          'name': null,
+                          'type': 1,
+                          'typeName': '[u8; 32]',
+                          'docs': [],
+                        },
+                      ],
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 1,
+                'type': {
+                  'path': [],
+                  'params': [],
+                  'def': {
+                    'array': {
+                      'len': 32,
+                      'type': 2,
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 2,
+                'type': {
+                  'path': [],
+                  'params': [],
+                  'def': {
+                    'primitive': 'U8',
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 6,
+                'type': {
+                  'path': [],
+                  'params': [],
+                  'def': {
+                    'primitive': 'U128',
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 47,
+                'type': {
+                  'path': [
+                    'pallet_im_online',
+                    'sr25519',
+                    'app_sr25519',
+                    'Public',
+                  ],
+                  'params': [],
+                  'def': {
+                    'composite': {
+                      'fields': [
+                        {
+                          'name': null,
+                          'type': 48,
+                          'typeName': 'sr25519::Public',
+                          'docs': [],
+                        },
+                      ],
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 48,
+                'type': {
+                  'path': ['sp_core', 'sr25519', 'Public'],
+                  'params': [],
+                  'def': {
+                    'composite': {
+                      'fields': [
+                        {
+                          'name': null,
+                          'type': 1,
+                          'typeName': '[u8; 32]',
+                          'docs': [],
+                        },
+                      ],
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 49,
+                'type': {
+                  'path': [],
+                  'params': [],
+                  'def': {
+                    'sequence': {
+                      'type': 50,
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 50,
+                'type': {
+                  'path': [],
+                  'params': [],
+                  'def': {
+                    'tuple': [0, 51],
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 51,
+                'type': {
+                  'path': ['pallet_staking', 'Exposure'],
+                  'params': [
+                    {
+                      'name': 'AccountId',
+                      'type': 0,
+                    },
+                    {
+                      'name': 'Balance',
+                      'type': 6,
+                    },
+                  ],
+                  'def': {
+                    'composite': {
+                      'fields': [
+                        {
+                          'name': 'total',
+                          'type': 52,
+                          'typeName': 'Balance',
+                          'docs': [],
+                        },
+                        {
+                          'name': 'own',
+                          'type': 52,
+                          'typeName': 'Balance',
+                          'docs': [],
+                        },
+                        {
+                          'name': 'others',
+                          'type': 53,
+                          'typeName':
+                            'Vec<IndividualExposure<AccountId, Balance>>',
+                          'docs': [],
+                        },
+                      ],
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 52,
+                'type': {
+                  'path': [],
+                  'params': [],
+                  'def': {
+                    'compact': {
+                      'type': 6,
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 53,
+                'type': {
+                  'path': [],
+                  'params': [],
+                  'def': {
+                    'sequence': {
+                      'type': 54,
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+              {
+                'id': 54,
+                'type': {
+                  'path': ['pallet_staking', 'IndividualExposure'],
+                  'params': [
+                    {
+                      'name': 'AccountId',
+                      'type': 0,
+                    },
+                    {
+                      'name': 'Balance',
+                      'type': 6,
+                    },
+                  ],
+                  'def': {
+                    'composite': {
+                      'fields': [
+                        {
+                          'name': 'who',
+                          'type': 0,
+                          'typeName': 'AccountId',
+                          'docs': [],
+                        },
+                        {
+                          'name': 'value',
+                          'type': 52,
+                          'typeName': 'Balance',
+                          'docs': [],
+                        },
+                      ],
+                    },
+                  },
+                  'docs': [],
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+    const eventTypes: SiType = registry.createType('SiType', {
+      'path': ['pallet_im_online', 'pallet', 'Event'],
+      'params': [
+        {
+          'name': 'T',
+          'type': null,
+        },
+      ],
+      'def': {
+        'variant': {
+          'variants': [
+            {
+              'name': 'HeartbeatReceived',
+              'fields': [
+                {
+                  'name': 'authority_id',
+                  'type': 47,
+                  'typeName': 'T::AuthorityId',
+                  'docs': [],
+                },
+              ],
+              'index': 0,
+              'docs': ['A new heartbeat was received from `AuthorityId`.'],
+            },
+            {
+              'name': 'AllGood',
+              'fields': [],
+              'index': 1,
+              'docs': ['At the end of the session, no offence was committed.'],
+            },
+            {
+              'name': 'SomeOffline',
+              'fields': [
+                {
+                  'name': 'offline',
+                  'type': 49,
+                  'typeName': 'Vec<IdentificationTuple<T>>',
+                  'docs': [],
+                },
+              ],
+              'index': 2,
+              'docs': [
+                'At the end of the session, at least one validator was found to be offline.',
+              ],
+            },
+          ],
+        },
+      },
+      'docs': [
+        '\n\t\t\tThe [event](https://docs.substrate.io/v3/runtime/events-and-errors) emitted\n\t\t\tby this pallet.\n\t\t\t',
+      ],
+    })
 
-    expect(types).to.include.members(['Vec', 'u32'])
-    expect(types).to.include.members(['AccountId', 'Codec'])
-    expect(types).to.include.members(['Balance', 'LookupSource'])
+    let types: string[] = []
+    eventTypes.def.asVariant.variants.forEach((v) => {
+      types = types.concat(extractTypesFromVariant(meta.asLatest, v))
+    })
+
     expect(types).to.include.members([
+      'AccountId32',
       'Vec',
-      'CategoryId',
-      'ThreadId',
-      'PostId',
-      'bool',
+      'PalletStakingExposure',
+      'PalletImOnlineSr25519AppSr25519Public',
     ])
   })
 })

--- a/packages/hydra-typegen/src/metadata/metadata.ts
+++ b/packages/hydra-typegen/src/metadata/metadata.ts
@@ -1,11 +1,8 @@
-import { MetadataLatest } from '@polkadot/types/interfaces'
 import { Metadata } from '@polkadot/types'
 import { TypeRegistry } from '@polkadot/types/create'
 import { WebSocket } from '@polkadot/x-ws'
 import BN from 'bn.js'
 import path from 'path'
-import { TypeDefs } from './types'
-import { readJson } from '../util'
 
 const debug = require('debug')('hydra-typegen:metadata')
 
@@ -26,7 +23,7 @@ interface ChainSpec {
 export async function getMetadata({
   source,
   blockHash,
-}: MetadataSource): Promise<MetadataLatest> {
+}: MetadataSource): Promise<Metadata> {
   let metaHex: string | undefined
   debug(`Reading metadata: from ${source}`)
 
@@ -37,28 +34,12 @@ export async function getMetadata({
     metaHex = require(path.join(process.cwd(), source)).result as string
   }
 
-  const meta = new Metadata(registry, metaHex)
+  const meta = new Metadata(registry, metaHex as `0x${string}`)
 
   registry.setMetadata(meta)
 
-  return meta.asLatest
+  return meta
 }
-
-export function registerCustomTypes(typeDefs: string): TypeDefs {
-  const typeDefsJson = readJson(typeDefs) as TypeDefs
-  registry.register(typeDefsJson)
-  debug(`Registered ${Object.keys(typeDefsJson).join(',')}`)
-  return typeDefsJson
-}
-
-// export function registerTypes(custom: CustomTypes = {}, spec?: ChainSpec) {
-//   registry.setKnownTypes({ types: custom })
-//   if (spec) {
-//     registry.register(
-//       getSpecTypes(registry, spec.chain, spec.name, spec.version)
-//     )
-//   }
-// }
 
 async function fromChain(
   endpoint: string,

--- a/packages/hydra-typegen/src/metadata/types.ts
+++ b/packages/hydra-typegen/src/metadata/types.ts
@@ -1,68 +1,24 @@
-import { Option, Vec } from '@polkadot/types/codec'
+import { PalletMetadataLatest } from '@polkadot/types/interfaces/metadata'
 import { Text } from '@polkadot/types/primitive'
-import { Codec } from '@polkadot/types/types'
 import { lowerCase } from 'lodash'
 
-export type Arg = {
-  type: Text
-  name: Text
-} & Codec
+export type ExtractedParam = {
+  name?: string
+  type: string
+}
 
-export type Call = {
-  args: Vec<Arg>
-  name: Text
-  documentation?: Vec<Text>
-} & Codec
+export type ExtractedVaraintData = {
+  params: ExtractedParam[]
+  documentation: string[]
+  name: string
+}
 
-export type Calls = Option<Vec<Call>>
-
-export type Event = {
-  args: Vec<Text>
-  documentation?: Vec<Text>
-  name: Text
-} & Codec
-
-export type ModuleMeta = {
-  module: Module
-  events: Event[]
-  calls: Call[]
+export type ExtractedModuleMeta = {
+  module: PalletMetadataLatest
+  events: ExtractedVaraintData[]
+  calls: ExtractedVaraintData[]
   types: string[]
 }
-
-export type Events = Option<Vec<Event>>
-
-export type Module = {
-  // V0
-  module?: {
-    call: {
-      functions: Vec<Call>
-    }
-  }
-  name: Text
-
-  // V1+
-  calls?: Calls
-  // V6+
-  constants?: Vec<{ type: Text } & Codec>
-  events?: Events
-} & Codec
-
-export interface ExtractedMetadata {
-  modules: Vec<Module>
-
-  // V0
-  outerEvent?: {
-    events: Vec<[Text, Vec<Event>] & Codec>
-  }
-}
-
-export type TypeDefs = Record<
-  string,
-  | string
-  | Record<string, string>
-  | { _enum: string[] | Record<string, string | null> }
-  | { _set: Record<string, number> }
->
 
 export function weakEquals(s1: string | Text, s2: string | Text): boolean {
   if (s1 === undefined || s2 === undefined) {

--- a/packages/hydra-typegen/src/templates/index.hbs
+++ b/packages/hydra-typegen/src/templates/index.hbs
@@ -1,15 +1,12 @@
-import { TypeRegistry } from '@polkadot/types'
-{{#if hasTypeDefs}}
+import { TypeRegistry, Metadata } from '@polkadot/types'
+import metadataHex from './metadata.json'
 import path from 'path'
 import fs from 'fs'
-{{/if}}
-const typeRegistry = new TypeRegistry()
 
-{{#if hasTypeDefs}}
-typeRegistry.register(
-  JSON.parse(fs.readFileSync(path.join(__dirname, 'typedefs.json'), 'utf-8'))
-)
-{{/if}}
+const typeRegistry = new TypeRegistry()
+const metadata = new Metadata(typeRegistry, metadataHex as `0x${string}`)
+
+typeRegistry.setMetadata(metadata)
 
 export {
   typeRegistry,

--- a/packages/hydra-typegen/test/config.spec.ts
+++ b/packages/hydra-typegen/test/config.spec.ts
@@ -7,32 +7,12 @@ import path from 'path'
 describe('config', () => {
   it('should parse config file', () => {
     const config = parseConfigFile(path.resolve('test/fixtures/config.yml'))
-    expect(config.customTypes?.typedefsLoc).not.to.be.an('undefined')
+    expect(config.metadata.source).not.to.be.an('undefined')
   })
 
   it('should throw if no events or calls were defined', () => {
     expect(() =>
-      validate(({ events: [], calls: [] } as unknown) as IConfig)
+      validate({ events: [], calls: [] } as unknown as IConfig)
     ).to.throw('Nothing to generate')
-  })
-
-  it('should throw if it cannot locate typedef files', () => {
-    expect(() =>
-      validate(({
-        events: ['a'],
-        calls: ['b'],
-        customTypes: { typedefsLoc: 'non-existent' },
-      } as unknown) as IConfig)
-    ).to.throw('Cannot find type definition')
-  })
-
-  it('should locate type defintions', () => {
-    expect(() =>
-      validate(({
-        events: ['a'],
-        calls: ['b'],
-        customTypes: { typedefsLoc: 'test/fixtures/typedefs.json' },
-      } as unknown) as IConfig)
-    ).not.to.throw()
   })
 })

--- a/packages/hydra-typegen/test/fixtures/config.yml
+++ b/packages/hydra-typegen/test/fixtures/config.yml
@@ -6,7 +6,4 @@ typegen:
     - Balances.Transfer
   calls:
     - Balances.transfer
-  customTypes:
-    lib: 'testing'
-    typedefsLoc: test-typedefs.json
   outDir: ./generated

--- a/packages/hydra-typegen/test/gen-index.spec.ts
+++ b/packages/hydra-typegen/test/gen-index.spec.ts
@@ -3,15 +3,19 @@ import tmp from 'tmp'
 import { GeneratorConfig, generateIndex } from '../src/generators'
 import path from 'path'
 import fs from 'fs'
+import { TypeRegistry } from '@polkadot/types'
 
 describe('gen-index', () => {
-  it('should copy type definition file', () => {
+  it('should create the metadata file', () => {
     const dest = tmp.dirSync().name
-    generateIndex(({
+    const registry = new TypeRegistry()
+    generateIndex({
       modules: [],
-      customTypes: { typedefsLoc: 'test/fixtures/typedefs.json' },
+      originalMetadata: registry.createType('Metadata', {
+        metadata: { v14: {} },
+      }),
       dest,
-    } as unknown) as GeneratorConfig)
-    expect(fs.existsSync(path.join(dest, 'typedefs.json'))).equal(true)
+    } as unknown as GeneratorConfig)
+    expect(fs.existsSync(path.join(dest, 'metadata.json'))).equal(true)
   })
 })

--- a/packages/hydra-typegen/tsconfig.json
+++ b/packages/hydra-typegen/tsconfig.json
@@ -1,20 +1,18 @@
 {
-    "compilerOptions": {
-        "declaration": true,
-        "importHelpers": true,
-        "module": "commonjs",
-        "outDir": "lib",
-        "rootDirs": [
-            "./src"
-        ],
-        "strict": true,
-        "target": "es2017",
-        "noImplicitAny": false,
-        "esModuleInterop": true,
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
-        "skipLibCheck": true, 
-        "types": [ "node", "mocha", "chai" ]
-    },
-    "include": ["./src/**/*"]
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "outDir": "lib",
+    "rootDirs": ["./src"],
+    "strict": true,
+    "target": "es2017",
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "types": ["node", "mocha", "chai"]
+  },
+  "include": ["./src/**/*"]
 }

--- a/packages/sample/mappings/package.json
+++ b/packages/sample/mappings/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@joystream/hydra-common": "^3.1.0-alpha.27",
-    "@polkadot/types": "5.9.1"
+    "@polkadot/types": "8.9.1"
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -39,8 +39,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/bn.js": "^4.11.6",
-    "bn.js": "^5.1.2",
+    "@types/bn.js": "^5.1.0",
+    "bn.js": "^5.2.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,10 +387,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.16.3":
-  version "7.16.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
-  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
+"@babel/runtime@^7.18.3":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1945,6 +1945,21 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@noble/hashes@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.1.tgz#c056d9b7166c1e7387a7453c2aff199bf7d88e5f"
+  integrity sha512-Lkp9+NijmV7eSVZqiUvt3UCuuHeJpUVmRrvh430gyJjJiuJMqkeHf6/A9lQ/smmbWV/0spDeJscscPzyB4waZg==
+
+"@noble/hashes@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
+  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
+"@noble/secp256k1@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.0.tgz#602afbbfcfb7e169210469b697365ef740d7e930"
+  integrity sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2307,211 +2322,417 @@
   dependencies:
     debug "^4.3.1"
 
-"@polkadot/api-derive@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-5.9.1.tgz#5937069920ded1439e6672b9d6be1072421b256b"
-  integrity sha512-iMrVKnYIS3UQciDlFqww6AFyXgG+iN8UqWu8QbTuZecri3qrSmM3Nn8Jkvju3meZIacwWIMSmBcnj8+zef3rkQ==
+"@polkadot/api-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-8.9.1.tgz#25b0997ccf3d1df4641123e0d9ec29e8fb03ef62"
+  integrity sha512-yobYURNgoZcZD3QJmE34n3ZcEEUtsiivquckxjJMXnHJv3zahMyJh75tCNAXjzWn+e+SqKTVlgCpLXYlC1HJPQ==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@polkadot/api" "5.9.1"
-    "@polkadot/rpc-core" "5.9.1"
-    "@polkadot/types" "5.9.1"
-    "@polkadot/util" "^7.3.1"
-    "@polkadot/util-crypto" "^7.3.1"
-    rxjs "^7.3.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/api@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-5.9.1.tgz#ce314cc34f0a47098d039db7b9036bb491c2898c"
-  integrity sha512-POpIXn/Ao+NLB0uMldXdXU44dVbRr6+6Ax77Z0R285M8Z2EiF5jl2K3SPvlowLo4SntxiCSaHQxCekYhUcJKlw==
+"@polkadot/api-base@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-base/-/api-base-8.9.1.tgz#e0013bbb8e72678a4eecdfb880854b2e30c840d5"
+  integrity sha512-2OpS9ArZSuUu9vg2Y5DdK7r1iB1Bjx9e+6qerPGry8um+jI+EsHJESylw5OUrR2DxvtW3Ilrk4YvYpQPa9OB4w==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@polkadot/api-derive" "5.9.1"
-    "@polkadot/keyring" "^7.3.1"
-    "@polkadot/rpc-core" "5.9.1"
-    "@polkadot/rpc-provider" "5.9.1"
-    "@polkadot/types" "5.9.1"
-    "@polkadot/types-known" "5.9.1"
-    "@polkadot/util" "^7.3.1"
-    "@polkadot/util-crypto" "^7.3.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    rxjs "^7.5.5"
+
+"@polkadot/api-derive@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-8.9.1.tgz#d701c98db27b86dceac6d3e737f0cab4f9731045"
+  integrity sha512-zOuNK1tApg3iEC5N4yiOTaMKUykk4tkNU1htcnotOxflgdhYUi22l0JuCrEtrnG6TE2ZH8z1VQA/jK0MbLfC3A==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api" "8.9.1"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    rxjs "^7.5.5"
+
+"@polkadot/api@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-8.9.1.tgz#c35c5d583845a5d67edfa8c3579bad143f65bcd6"
+  integrity sha512-UwQ5hWPHruqnBO2hriaPhGaOwaWZx9MVECWFJzVs0ZuhKDge9jyBp+JXud/Ly/+8VbeokYUB0DSZG/gTAO5+vg==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/api-augment" "8.9.1"
+    "@polkadot/api-base" "8.9.1"
+    "@polkadot/api-derive" "8.9.1"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/types-known" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
     eventemitter3 "^4.0.7"
-    rxjs "^7.3.0"
+    rxjs "^7.5.5"
 
-"@polkadot/keyring@7.9.2", "@polkadot/keyring@^7.3.1":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-7.9.2.tgz#1f5bf6b7bdb5942d275aebf72d4ed98abe874fa8"
-  integrity sha512-6UGoIxhiTyISkYEZhUbCPpgVxaneIfb/DBVlHtbvaABc8Mqh1KuqcTIq19Mh9wXlBuijl25rw4lUASrE/9sBqg==
+"@polkadot/keyring@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-9.5.1.tgz#3b0851f8fffe489f1b6020e69dc9a3a8e5696172"
+  integrity sha512-ixv2lq1zNzYa+GqZQTzcraNw5ZrTTK+2/sqfeMOIr7gBGk0UCALuK0NCvTRAUtQK1RT2psBkkm2lr/rrNCeK+A==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/util" "7.9.2"
-    "@polkadot/util-crypto" "7.9.2"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/util-crypto" "9.5.1"
 
-"@polkadot/networks@7.9.2", "@polkadot/networks@^7.3.1":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-7.9.2.tgz#03e3f3ac6bdea177517436537826055df60bcb9a"
-  integrity sha512-4obI1RdW5/7TFwbwKA9oqw8aggVZ65JAUvIFMd2YmMC2T4+NiZLnok0WhRkhZkUnqjLIHXYNwq7Ho1i39dte0g==
+"@polkadot/keyring@^9.5.1":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-9.6.2.tgz#8f413b81ed293c7cb5938a85259e4f6381581749"
+  integrity sha512-xcFx0m01G4jcYqEPJQQqF7Dn62x180G4TXaBR4iOTrjvNwmxx4PgIXN2DodHezb1dJLNSE0lu89OasID/dNNxA==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.6.2"
+    "@polkadot/util-crypto" "9.6.2"
 
-"@polkadot/rpc-core@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-5.9.1.tgz#68e2a2ea18c15aa15743e7487a407fdd65d1d900"
-  integrity sha512-5fXiICAcjp7ow81DnIl2Dq/xuCtJUqyjJkxe9jNHJWBluBxOouqYDb8bYPPGSdckiaVyYe0l8lA9fBUFMdEt6w==
+"@polkadot/networks@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-9.5.1.tgz#876c6cf8915a47e6ace81139197f8b0d36adb362"
+  integrity sha512-1q9jm7NLk1ZMqFJL+kYkpn1phEO+N0d5LU81ropjYf0hC9boBAya4Zqvv3DwasPuLp6qaj4r0nrfzmkP5xHKZQ==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@polkadot/rpc-provider" "5.9.1"
-    "@polkadot/types" "5.9.1"
-    "@polkadot/util" "^7.3.1"
-    rxjs "^7.3.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.5.1"
+    "@substrate/ss58-registry" "^1.22.0"
 
-"@polkadot/rpc-provider@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-5.9.1.tgz#8e67769c05ba71ecf4f5bc0c5a60eb9afc699167"
-  integrity sha512-9zamxfnsY7iCswXIK22W0Ji1XHLprm97js3WLw3lP2hr/uSim4Cv4y07zY/z4dDQyF0gJtjKwR27Wo9CZqdr6A==
+"@polkadot/networks@9.6.2", "@polkadot/networks@^9.5.1":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-9.6.2.tgz#0011683682d74d265005b3169023384cd65fb89b"
+  integrity sha512-zTQkZGRSvgrj/XH1vUz1y1kZOhxT9qUn3T1BfMclbSBdyb+ugI+KLZhYffzfbl1YkQPyrR4MTpueHK40SjGaHg==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@polkadot/types" "5.9.1"
-    "@polkadot/util" "^7.3.1"
-    "@polkadot/util-crypto" "^7.3.1"
-    "@polkadot/x-fetch" "^7.3.1"
-    "@polkadot/x-global" "^7.3.1"
-    "@polkadot/x-ws" "^7.3.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "9.6.2"
+    "@substrate/ss58-registry" "^1.22.0"
+
+"@polkadot/rpc-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-augment/-/rpc-augment-8.9.1.tgz#644061c68a9a2abe7f3574ab74b10652acae5707"
+  integrity sha512-6TtZPVjvjcPy3w4lmcNu3MTU1h2YLkZBVNwUZFnZPhALc9qBy9ZcvkMODLPfD+mj+i8Fcfn4b7Ypj+sNqXFxUQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-core" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+
+"@polkadot/rpc-core@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-8.9.1.tgz#79392d2a1d1d5e93549cd0f7fae7f0d71a6fb79d"
+  integrity sha512-+mAkpxIX2kIovnIIf8uxqjXqPA/7LaeysfIPi8VGrVB3IqvLEaT2rWtCMRSFkBEZwYI7vP7PrAw9co6MMkXlUw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/rpc-augment" "8.9.1"
+    "@polkadot/rpc-provider" "8.9.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    rxjs "^7.5.5"
+
+"@polkadot/rpc-provider@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-8.9.1.tgz#1e6e8e6218bb0fe59dd673acb9198bf12acf6625"
+  integrity sha512-XunL29pi464VB6AJGuvVzTnCtk4y5KBwgBIC/S4YMdqi+l2ujXZOFM2WBnbiV+YhB7FEXmbYR8NsKAe/DSb85A==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-support" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    "@polkadot/x-fetch" "^9.5.1"
+    "@polkadot/x-global" "^9.5.1"
+    "@polkadot/x-ws" "^9.5.1"
+    "@substrate/connect" "0.7.6"
     eventemitter3 "^4.0.7"
+    mock-socket "^9.1.5"
+    nock "^13.2.6"
 
-"@polkadot/ts@^0.3.14":
-  version "0.3.91"
-  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.3.91.tgz#4a20c3fa4a28429774cef3311c572c697ad3e7a0"
-  integrity sha512-4MHxCZEe+ckoeRU3hCp2khcVJn2G/N4BLYyUMALeO/jTjJbGxclTw9WfMtEK8gSqfGkNPpLgWTfaZPDH0sHcRA==
+"@polkadot/types-augment@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-8.9.1.tgz#ff4880471eba038f8b28e412b7d8d1f500d46cf9"
+  integrity sha512-kfSioIpB8krtNgIANN8QCik+uBFmxGACEq84oxiqbKc2BfTXzcqQ7jkmslXeEqb9IsQ9rpaa3fkvyoLQNLqXgA==
   dependencies:
-    "@types/chrome" "^0.0.145"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types-known@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-5.9.1.tgz#e52fc7b803bc7cb3f41028f88963deb4ccee40af"
-  integrity sha512-7lpLuIVGaKziQRzPMnTxyjlYy3spL6WqUg3CcEzmJUKQeUonHglOliQh8JSSz1bcP+YuNHGXK1cKsTjHb+GYxA==
+"@polkadot/types-codec@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-8.9.1.tgz#8fbf3ade7a87b716937b7f37fd43b8a46ba12c4d"
+  integrity sha512-bboHpTwvHooTdITsmJ5IqAyZDuONZaVs6xC3iRbE9SIHD4kUpivlTc+Rvk91EcQclFo5IUKvNrX4BrOx8Y/YnQ==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@polkadot/networks" "^7.3.1"
-    "@polkadot/types" "5.9.1"
-    "@polkadot/util" "^7.3.1"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/types@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-5.9.1.tgz#74cf4695795f2aa365ff85d3873e22c430100bc9"
-  integrity sha512-30vcSlNBxPyWYZaxKDr/BoMhfLCRKB265XxpnnNJmbdZZsL+N4Zp2mJR9/UbA6ypmJBkUjD7b1s9AYsLwUs+8w==
+"@polkadot/types-create@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-8.9.1.tgz#ed365812b522fcc7984aa24cf7cbeeb0cdf20e34"
+  integrity sha512-q7er671QXYcmG4gkZvtKpES7QV013w36s8VT947aT3GDzlGZDQQKNKpELyi7K1sgWjQyrL3/0cTKhP8taAjWPQ==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@polkadot/util" "^7.3.1"
-    "@polkadot/util-crypto" "^7.3.1"
-    rxjs "^7.3.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/util" "^9.5.1"
 
-"@polkadot/util-crypto@7.9.2", "@polkadot/util-crypto@^7.3.1":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-7.9.2.tgz#cdc336f92a6bc3d40c5a23734e1974fb777817f0"
-  integrity sha512-nNwqUwP44eCH9jKKcPie+IHLKkg9LMe6H7hXo91hy3AtoslnNrT51tP3uAm5yllhLvswJfnAgnlHq7ybCgqeFw==
+"@polkadot/types-known@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-8.9.1.tgz#019ab25b048f157659cf6141c3d8483c28af0123"
+  integrity sha512-y5Fvo7TM9DjM/CNQbQsR78O5LP3CuBbQY90yA2APwqZNn/dilTxWIGrxtPzTG9QCZJyhMN+EZdKUo51brKRI/g==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/networks" "7.9.2"
-    "@polkadot/util" "7.9.2"
-    "@polkadot/wasm-crypto" "^4.4.1"
-    "@polkadot/x-randomvalues" "7.9.2"
-    blakejs "^1.1.1"
-    bn.js "^4.12.0"
-    create-hash "^1.2.0"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/networks" "^9.5.1"
+    "@polkadot/types" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+
+"@polkadot/types-support@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-support/-/types-support-8.9.1.tgz#84d023945feddc15f60b8cb1a36abe2edfed4a23"
+  integrity sha512-t3HJc8o68LWvhEy63PRZQxCL4T7sSsrLm7+rpkfeJAEC1DXeFF85FwE2U+YKa3+Z3NuMv2e4DV2jnIZe9XRtHQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/util" "^9.5.1"
+
+"@polkadot/types@8.9.1":
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-8.9.1.tgz#e5bf1cef79d8c305faa8691c62dd3d4be9baed53"
+  integrity sha512-h43/aPzk+ta0MzzGQz3DiGtearttHxZr08xOdtU5GctI6u9MXm0n0w74clciLpIGu5CI+QxYN3oQ8/5WXTukMw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/keyring" "^9.5.1"
+    "@polkadot/types-augment" "8.9.1"
+    "@polkadot/types-codec" "8.9.1"
+    "@polkadot/types-create" "8.9.1"
+    "@polkadot/util" "^9.5.1"
+    "@polkadot/util-crypto" "^9.5.1"
+    rxjs "^7.5.5"
+
+"@polkadot/util-crypto@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-9.5.1.tgz#f69bdccd7043620c9bd905b169ec50bf97bf6ffb"
+  integrity sha512-4YwJJ2/mXx3PXTy4WLekQOo1MlDtQzYgTZsjOagi3Uz3Q/ITvS+/iu6eF/H6Tz0uEQjwX6t9tsMkM5FWk/XoGg==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@noble/hashes" "1.1.1"
+    "@noble/secp256k1" "1.6.0"
+    "@polkadot/networks" "9.5.1"
+    "@polkadot/util" "9.5.1"
+    "@polkadot/wasm-crypto" "^6.1.1"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-randomvalues" "9.5.1"
+    "@scure/base" "1.1.1"
     ed2curve "^0.3.0"
-    elliptic "^6.5.4"
-    hash.js "^1.1.7"
-    js-sha3 "^0.8.0"
-    micro-base "^0.9.0"
-    scryptsy "^2.1.0"
     tweetnacl "^1.0.3"
-    xxhashjs "^0.2.2"
 
-"@polkadot/util@7.9.2", "@polkadot/util@^7.3.1":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-7.9.2.tgz#567ac659516d6b685ed7e796919901d92e5cbe6b"
-  integrity sha512-6ABY6ErgkCsM4C6+X+AJSY4pBGwbKlHZmUtHftaiTvbaj4XuA4nTo3GU28jw8wY0Jh2cJZJvt6/BJ5GVkm5tBA==
+"@polkadot/util-crypto@9.6.2", "@polkadot/util-crypto@^9.5.1":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-9.6.2.tgz#643d6118df8f4a6873855522166c47a76eb2aec1"
+  integrity sha512-ptr4RnVevjW5Sel3JjLJUaT1YmG04zeof4hddJJuQ/H8S/WIkv4uRgT9lkjw54U/DB+qS44XO/uIGMlR7BtLQg==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/x-textdecoder" "7.9.2"
-    "@polkadot/x-textencoder" "7.9.2"
-    "@types/bn.js" "^4.11.6"
-    bn.js "^4.12.0"
-    camelcase "^6.2.1"
+    "@babel/runtime" "^7.18.3"
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.6.0"
+    "@polkadot/networks" "9.6.2"
+    "@polkadot/util" "9.6.2"
+    "@polkadot/wasm-crypto" "^6.1.5"
+    "@polkadot/x-bigint" "9.6.2"
+    "@polkadot/x-randomvalues" "9.6.2"
+    "@scure/base" "1.1.1"
+    ed2curve "^0.3.0"
+    tweetnacl "^1.0.3"
+
+"@polkadot/util@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-9.5.1.tgz#b9e0b8cb0d6f1fd86e1a39a843ac8defeb6d5c9f"
+  integrity sha512-cI2ar15vkoXjs//YNn1yT5eUdK7jF32XNw3Oc6YJ2qEpenwy30c3BUQJOiqW7J6UBYLYll5O5y0ejv6LQoSFBQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-bigint" "9.5.1"
+    "@polkadot/x-global" "9.5.1"
+    "@polkadot/x-textdecoder" "9.5.1"
+    "@polkadot/x-textencoder" "9.5.1"
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.2.1"
     ip-regex "^4.3.0"
 
-"@polkadot/wasm-crypto-asmjs@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.5.1.tgz#e1025a49e106db11d1187caf65f56c960ea2ad2b"
-  integrity sha512-DOdRiWhxVvmqTvp+E9z1j+Yr0zDOGsDvqnT/eNw0Dl1FVUOImsEa7FKns/urASmcxCVEE1jtUWSnij29jrORMQ==
+"@polkadot/util@9.6.2", "@polkadot/util@^9.5.1":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-9.6.2.tgz#ad011b04f941bf7ce62babfd8ea32180ed985caf"
+  integrity sha512-ebK46kEsXfzqUgaPVbVOZepHtVJR2qd9FHTLBPcoXR601y6IuqCHkp0hMkrD3Cdi5AWAd0a7h84c1/Oj5q3SnA==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-bigint" "9.6.2"
+    "@polkadot/x-global" "9.6.2"
+    "@polkadot/x-textdecoder" "9.6.2"
+    "@polkadot/x-textencoder" "9.6.2"
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.2.1"
+    ip-regex "^4.3.0"
 
-"@polkadot/wasm-crypto-wasm@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.5.1.tgz#063a58ff7ddd939b7886a6a238109a8d2c416e46"
-  integrity sha512-hPwke85HxpgG/RAlwdCE8u5w7bThvWg399mlB+XjogXMxOUWBZSgq2XYbgzROUXx27inK9nStF4Pnc4zJnqs9A==
+"@polkadot/wasm-bridge@6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-bridge/-/wasm-bridge-6.1.5.tgz#f77e3605eb30ac199a8d3a6357affb35f81f983a"
+  integrity sha512-nqxhJQTjw5P3yEY1Cd9g86GvpY/PHD3h74dszaBOg5GVPE53G18AKehb5I8daSpOHVKsItKK1n8xstxZTVI0Hg==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.18.3"
 
-"@polkadot/wasm-crypto@^4.4.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.5.1.tgz#e1ac6d846a0ad8e991cec128994524183ef6e8fd"
-  integrity sha512-Cr21ais3Kq3aedIHZ3J1tjgeD/+K8FCiwEawr0oRywNBSJR8wyuZMePs4swR/6xm8wbBkpqoBVHz/UQHqqQJmA==
+"@polkadot/wasm-crypto-asmjs@6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.1.5.tgz#2446159502fc3966cdcc4a9560494e037bdec3ab"
+  integrity sha512-GsVIe+fjJ2sHfrjtqSLV0tP6nClF/7/QXZd+BAWomVMCVcR35OIrkNK2giDzlCqaTP+MiCb/UF3phrU4wsHV4Q==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/wasm-crypto-asmjs" "^4.5.1"
-    "@polkadot/wasm-crypto-wasm" "^4.5.1"
+    "@babel/runtime" "^7.18.3"
 
-"@polkadot/x-fetch@^7.3.1":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-7.9.2.tgz#fe943be5854f7355630388b1b5d2bb52f1a3afb2"
-  integrity sha512-zutLkFJVaLVpY3cIGYJD0AReLfAnPr2J82Ca4pvy/BxqwwGYuGLcn36A4m6nliGBP2lcH4oYY+mcCqIwoPWQUQ==
+"@polkadot/wasm-crypto-init@6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.1.5.tgz#86756bc85bffced837778c2c2d35dab69adfb8f5"
+  integrity sha512-VkBNc4cEkQ9YWAKLGW2ve2HV56GBHii3Xy4QYV+8OFYiOUbBMDVmuAvjlCjxiwa8nUxLzgCIz0HqqUx2YzxkhQ==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/x-global" "7.9.2"
-    "@types/node-fetch" "^2.5.12"
-    node-fetch "^2.6.6"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/wasm-bridge" "6.1.5"
+    "@polkadot/wasm-crypto-asmjs" "6.1.5"
+    "@polkadot/wasm-crypto-wasm" "6.1.5"
 
-"@polkadot/x-global@7.9.2", "@polkadot/x-global@^7.3.1":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-7.9.2.tgz#b272b0a3bedaad3bcbf075ec4682abe68cf2a850"
-  integrity sha512-JX5CrGWckHf1P9xKXq4vQCAuMUbL81l2hOWX7xeP8nv4caHEpmf5T1wD1iMdQBL5PFifo6Pg0V6/oZBB+bts7A==
+"@polkadot/wasm-crypto-wasm@6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.1.5.tgz#1a694958b8aedf1908d0abf4d30a95e68219cef8"
+  integrity sha512-YKriV8xUnnNVCykB0c1r0JEQgGPmgPMsEfHLzKhUeE415vkj3UcfcgXuOXVSEXKqgeoCLkvlY5OL3yb3Fg+Xbw==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/wasm-util" "6.1.5"
 
-"@polkadot/x-randomvalues@7.9.2":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-7.9.2.tgz#0c9bb7b48a0791c2a32e9605a31a5ce56fee621d"
-  integrity sha512-svQfG31yCXf6yVyIgP0NgCzEy7oc3Lw054ZspkaqjOivxYdrXaf5w3JSSUyM/MRjI2+nk+B/EyJoMYcfSwTfsQ==
+"@polkadot/wasm-crypto@^6.1.1", "@polkadot/wasm-crypto@^6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-6.1.5.tgz#a7f60ebf81297a460fa1e97f71c4db6c91d49639"
+  integrity sha512-P4MIVE0RJm+Ar0qbOFFtEvA9fkrcmu4KI929k/XiWOqqKuLogwNjZcZiWZYLG7pDIXeHciAy65nIUpV2nr0D+Q==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/x-global" "7.9.2"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/wasm-bridge" "6.1.5"
+    "@polkadot/wasm-crypto-asmjs" "6.1.5"
+    "@polkadot/wasm-crypto-init" "6.1.5"
+    "@polkadot/wasm-crypto-wasm" "6.1.5"
+    "@polkadot/wasm-util" "6.1.5"
 
-"@polkadot/x-textdecoder@7.9.2":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-7.9.2.tgz#a78548e33efeb3a25f761fec9787b2bcae7f0608"
-  integrity sha512-wfwbSHXPhrOAl12QvlIOGNkMH/N/h8PId2ytIjvM/8zPPFB5Il6DWSFLtVapOGEpIFjEWbd5t8Td4pHBVXIEbg==
+"@polkadot/wasm-util@6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-util/-/wasm-util-6.1.5.tgz#4dcd4a32d706e18a40c2de65813abad1b4cbf730"
+  integrity sha512-5OH31mz8/Ly50fNOQ6eGFcO8OtLLyTvaoJPqUmcdl6OI+1+8GLoZMoXyRdrhWjftqQFxiJnwvlpqq6VdNVDg6g==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/x-global" "7.9.2"
+    "@babel/runtime" "^7.18.3"
 
-"@polkadot/x-textencoder@7.9.2":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-7.9.2.tgz#b32bfd6fbff8587c56452f58252a52d62bbcd5b9"
-  integrity sha512-A19wwYINuZwU2dUyQ/mMzB0ISjyfc4cISfL4zCMUAVgj7xVoXMYV2GfjNdMpA8Wsjch3su6pxLbtJ2wU03sRTQ==
+"@polkadot/x-bigint@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-9.5.1.tgz#d5d98aaa6b3de560eea23df9f696903f2e2dcf7c"
+  integrity sha512-rTp7j3KvCy8vANRoaW6j0pCQdLc/eed6uSRXoxh3z1buJhw460/Q/hJ0Bey6fyeNSDzIwFk4SGwf/Gzf+kS1vQ==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/x-global" "7.9.2"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
 
-"@polkadot/x-ws@^7.3.1":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-7.9.2.tgz#016df26fa829b74f8b1e31a1dcd6e34256c1231f"
-  integrity sha512-+yppMsZtvDztVOSmkqAQuhR6TfV1Axa6ergAsWb52DrfXvFP5geqtARsI6ZdDgMsE3qHSVQTcJz8vgNOr5+ztQ==
+"@polkadot/x-bigint@9.6.2":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-9.6.2.tgz#1fa6038395fd488b7c0051113813de9a645a208b"
+  integrity sha512-p2PAx5uJM4zGhbDCEMiFbeOndP8bnzdEdvB4aP17o4AQ8iHM/TrhiOMD7xYeUtMpc0TP+Z6X0ZRqsAt4jBzoRg==
   dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@polkadot/x-global" "7.9.2"
-    "@types/websocket" "^1.0.4"
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.6.2"
+
+"@polkadot/x-fetch@^9.5.1":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-9.6.2.tgz#709019626a5618805516bbdd3701e26781b3e849"
+  integrity sha512-nTZOzpmgj+f5KxRcZxValpgnAc2xxefY84XaF3XKcQQBfQrN+/Kssfl5VjAoCGfBSpVVzXs/4/cN0oee5BldMQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.6.2"
+    "@types/node-fetch" "^2.6.2"
+    node-fetch "^2.6.7"
+
+"@polkadot/x-global@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-9.5.1.tgz#a78e109ca95f5ba5e9c501a2106a9b3acfe3a682"
+  integrity sha512-asG5YlW1K3f4YjyuZ+HrbF9H5d78i5v9+7Bh+9gD+sVfB3KhqwVYZB+wzOaJkPp6lwUbBA9OBHFCVBqpR3wBJw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+
+"@polkadot/x-global@9.6.2", "@polkadot/x-global@^9.5.1":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-9.6.2.tgz#caf4a140fe9902a2649c029db43b5424b85cdde8"
+  integrity sha512-cbrNeMK6vPEWh2EbLU+hUOERkOAToZ7o2wYYS+ZNdunvUFL9wERB9Uj6JQDAebGD3ZCNHEpMbj6U1WEffiwq9A==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+
+"@polkadot/x-randomvalues@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-9.5.1.tgz#e647554f7b34d4073e1bc60d8b81163d5f75f523"
+  integrity sha512-NFvG//NsBjFP01dEtQATNPn5lSAZwh6jkkUXG2rHlgvW6k8nVJ0aJPvO5MlgItgS5Ry2F88AIiSsO3cfoTpszg==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+
+"@polkadot/x-randomvalues@9.6.2":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-9.6.2.tgz#8555710235f649c14ea28c25919bed6c0e4202bb"
+  integrity sha512-GuyTYTkKK6MLPcfWX3rKRze3nUYjdRYWK1PKscslRp0Qq4LBTkroqlE7SMTt8Bh7DYH+0fWN2CmHGdv2oEUq9A==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.6.2"
+
+"@polkadot/x-textdecoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-9.5.1.tgz#13c1b48b12d350b635de385c8a0e2be14210b620"
+  integrity sha512-bY0J3Tov5y4oZi8qB/UtoEYCSgo5sDiiOa3Wmgen09LfB4gXJhWFGJSmcZqHERXCdEcmZojdbHTvOGSeYM9U1w==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+
+"@polkadot/x-textdecoder@9.6.2":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-9.6.2.tgz#d2e10e96ce2c89fcb3f020bea09e2943dc55a11a"
+  integrity sha512-nWd2sWU7vjUON4FSd6B2aSYmgkooYf1V+kjTPs8uV/PN6KMc6qJInrt4U1vnOvM8wX5+4gvLDs72AVxnFmVRAA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.6.2"
+
+"@polkadot/x-textencoder@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-9.5.1.tgz#76d79d07bb81e9cc7eff97043eae82c39189d8d9"
+  integrity sha512-zt121nqxiudMeZnanpnfWhCE0SOTcVRqn/atqO59us/yf6LMTf23mgd7P4795TgJwXOUcui4fhm/g/VcpsLq9Q==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.5.1"
+
+"@polkadot/x-textencoder@9.6.2":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-9.6.2.tgz#e0d3c37094bc19dd55ee3f0659a5a6b69ef43b91"
+  integrity sha512-T+ZsR2cVJxmpN6VB4u3BoWCg3fUlXHPNGCZSGXZdH2+dljIQl6MXqe+mHd5jknGvyBWCrJ0ijqoSOtLeP88MhA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.6.2"
+
+"@polkadot/x-ws@^9.5.1":
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-9.6.2.tgz#ad6ba74968a3714647c1eaefdd2af9196e0df54c"
+  integrity sha512-DT10DqFzM2PGe+0tmClgF5G7biM/akVpAQ9JGIdwV8PxWFWjxbhRasndPfVZEmCi2o8KIVlP6m1qovfS2PdbHA==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@polkadot/x-global" "9.6.2"
+    "@types/websocket" "^1.0.5"
     websocket "^1.0.34"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
@@ -2618,6 +2839,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@scure/base@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
+
 "@semantic-release/commit-analyzer@^6.1.0":
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.3.tgz#885f7e46e2f0aef23a23be0904dbf18d6ece45ca"
@@ -2669,6 +2895,34 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.3.tgz#1185726610acc37317ddab11c3c7f9066966bd20"
   integrity sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg==
+
+"@substrate/connect-extension-protocol@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@substrate/connect-extension-protocol/-/connect-extension-protocol-1.0.0.tgz#d452beda84b3ebfcf0e88592a4695e729a91e858"
+  integrity sha512-nFVuKdp71hMd/MGlllAOh+a2hAqt8m6J2G0aSsS/RcALZexxF9jodbFc62ni8RDtJboeOfXAHhenYOANvJKPIg==
+
+"@substrate/connect@0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@substrate/connect/-/connect-0.7.6.tgz#4b1cca6bf9c0e8be93f6f6a4eeb6684993f5dc18"
+  integrity sha512-PHizR91CbjC5bzUwgYUZJrbOyoraCS1QqoxkFHteZ/0vkXDKyuzoixobDaITJqq6wSTeM8ZSjuOn9u/3q7F5+A==
+  dependencies:
+    "@substrate/connect-extension-protocol" "^1.0.0"
+    "@substrate/smoldot-light" "0.6.19"
+    eventemitter3 "^4.0.7"
+
+"@substrate/smoldot-light@0.6.19":
+  version "0.6.19"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.6.19.tgz#13e897ca9839aecb0dac4ce079ff1cca1dc54cc0"
+  integrity sha512-Xi+v1cdURhTwx7NH+9fa1U9m7VGP61GvB6qwev9HrZXlGbQiUIvySxPlH/LMsq3mwgiRYkokPhcaZEHufY7Urg==
+  dependencies:
+    buffer "^6.0.1"
+    pako "^2.0.4"
+    websocket "^1.0.32"
+
+"@substrate/ss58-registry@^1.22.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.23.0.tgz#6212bf871a882da98799f8dc51de0944d4152b88"
+  integrity sha512-LuQje7n48GXSsp1aGI6UEmNVtlh7OzQ6CN1Hd9VGUrshADwMB0lRZ5bxnffmqDR4vVugI7h0NN0AONhIW1eHGg==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -2802,14 +3056,6 @@
   dependencies:
     chalk "*"
 
-"@types/chrome@^0.0.145":
-  version "0.0.145"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.145.tgz#6c53ae0af5f25350b07bfd24cf459b5fe65cd9b8"
-  integrity sha512-vLvTMmfc8mvwOZzkmn2UwlWSNu0t0txBkyuIv8NgihRkvFCe6XJX65YZAgAP/RdBit3enhU2GTxCr+prn4uZmA==
-  dependencies:
-    "@types/filesystem" "*"
-    "@types/har-format" "*"
-
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -2892,18 +3138,6 @@
   resolved "https://registry.yarnpkg.com/@types/figlet/-/figlet-1.5.4.tgz#54a426d63e921a9bca44102c5b1b1f206fa56d93"
   integrity sha512-cskPTju7glYgzvkJy/hftqw7Fen3fsd0yrPOqcbBLJu+YdDQuA438akS1g+2XVKGzsQOnXGV2I9ePv6xUBnKMQ==
 
-"@types/filesystem@*":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.32.tgz#307df7cc084a2293c3c1a31151b178063e0a8edf"
-  integrity sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==
-  dependencies:
-    "@types/filewriter" "*"
-
-"@types/filewriter@*":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
-  integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
-
 "@types/fs-capacitor@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz#17113e25817f584f58100fb7a08eed288b81956e"
@@ -2960,11 +3194,6 @@
   integrity sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==
   dependencies:
     graphql "*"
-
-"@types/har-format@*":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.7.tgz#debfe36378f26c4fc2abca1df99f00a8ff94fd29"
-  integrity sha512-/TPzUG0tJn5x1TUcVLlDx2LqbE58hyOzDVAc9kf8SpOEmguHjU6bKUyfqb211AdqLOmU/SNyXvLKPNP5qTlfRw==
 
 "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
@@ -3141,10 +3370,10 @@
   resolved "https://registry.yarnpkg.com/@types/node-emoji/-/node-emoji-1.8.1.tgz#689cb74fdf6e84309bcafce93a135dfecd01de3f"
   integrity sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==
 
-"@types/node-fetch@^2.5.12":
-  version "2.5.12"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
-  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -3351,10 +3580,10 @@
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.6.5.tgz#e9f5b23ebc51100db7ac38f7e950746f8f580c8b"
   integrity sha512-ilpDKpjjq/w/IyyTuQ38mABdaEzTzTugPyU7DlMCMKd8MMYngnPKhA2TgdO1MfEDED9KVV7uSOL1fDkgwJp/wg==
 
-"@types/websocket@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.4.tgz#1dc497280d8049a5450854dd698ee7e6ea9e60b8"
-  integrity sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==
+"@types/websocket@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.5.tgz#3fb80ed8e07f88e51961211cd3682a3a4a81569c"
+  integrity sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==
   dependencies:
     "@types/node" "*"
 
@@ -4515,11 +4744,6 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blakejs@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
-  integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
-
 blessed@0.1.81:
   version "0.1.81"
   resolved "https://registry.yarnpkg.com/blessed/-/blessed-0.1.81.tgz#f962d687ec2c369570ae71af843256e6d0ca1129"
@@ -4530,12 +4754,7 @@ bluebird@^3.3.5, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-bn.js@^4.11.9, bn.js@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
-  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
-
-bn.js@^5.1.2, bn.js@^5.1.3, bn.js@^5.2.0:
+bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
@@ -4598,11 +4817,6 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-brorand@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-fingerprint@0.0.1:
   version "0.0.1"
@@ -4683,7 +4897,7 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-buffer@^6.0.3:
+buffer@^6.0.1, buffer@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -4884,11 +5098,6 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-camelcase@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
-  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
-
 camelize@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
@@ -5062,14 +5271,6 @@ ci-info@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
   integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
-
-cipher-base@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
-  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
@@ -5891,17 +6092,6 @@ cp-file@^6.2.0:
     pify "^4.0.1"
     safe-buffer "^5.0.1"
 
-create-hash@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
-  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
-  dependencies:
-    cipher-base "^1.0.1"
-    inherits "^2.0.1"
-    md5.js "^1.3.4"
-    ripemd160 "^2.0.1"
-    sha.js "^2.4.0"
-
 create-react-class@^15.5.1:
   version "15.7.0"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
@@ -6025,11 +6215,6 @@ cuid@^1.3.8:
     browser-fingerprint "0.0.1"
     core-js "^1.1.1"
     node-fingerprint "0.0.2"
-
-cuint@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
-  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
 
 culvert@^0.1.2:
   version "0.1.2"
@@ -6652,19 +6837,6 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
-
-elliptic@^6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
 
 emitter-listener@^1.1.1:
   version "1.1.2"
@@ -8241,7 +8413,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -8250,6 +8422,18 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, gl
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.2.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -8694,23 +8878,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hash-base@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
-  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
-  dependencies:
-    inherits "^2.0.4"
-    readable-stream "^3.6.0"
-    safe-buffer "^5.2.0"
-
-hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.1"
-
 hasha@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39"
@@ -8752,15 +8919,6 @@ history@^4.7.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
-
-hmac-drbg@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
-  dependencies:
-    hash.js "^1.0.3"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.1"
 
 hoek@6.x.x:
   version "6.1.3"
@@ -10524,11 +10682,6 @@ js-git@^0.7.8:
     git-sha1 "^0.1.2"
     pako "^0.2.5"
 
-js-sha3@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -11470,15 +11623,6 @@ marked@^0.8.2:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
   integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
-md5.js@^1.3.4:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
-  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-    safe-buffer "^5.1.2"
-
 mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
@@ -11595,11 +11739,6 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micro-base@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/micro-base/-/micro-base-0.9.0.tgz#09cfe20285bec0ea97f41dc3d10e3fba3d0266ee"
-  integrity sha512-4+tOMKidYT5nQ6/UNmYrGVO5PMcnJdfuR4NC8HK8s2H61B4itOhA9yrsjBdqGV7ecdtej36x3YSIfPLRmPrspg==
-
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -11659,20 +11798,17 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
-
-minimalistic-crypto-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
-  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
-
 minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -11855,6 +11991,11 @@ mocha@^9.0.2:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
+
+mock-socket@^9.1.5:
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.1.5.tgz#2c4e44922ad556843b6dfe09d14ed8041fa2cdeb"
+  integrity sha512-3DeNIcsQixWHHKk6NdoBhWI4t1VMj5/HzfnI1rE/pLl5qKx7+gd4DNA07ehTaZ6MoUU053si6Hd+YtiM/tQZfg==
 
 mock-stdin@^1.0.0:
   version "1.0.0"
@@ -12056,6 +12197,16 @@ nock@^13.0.0:
     lodash.set "^4.3.2"
     propagate "^2.0.0"
 
+nock@^13.2.6:
+  version "13.2.7"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.7.tgz#c93933b61df42f4f4b3a07fde946a4e209c0c168"
+  integrity sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
+
 node-emoji@^1.10.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
@@ -12092,10 +12243,10 @@ node-fetch@^2.5.0, node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -12906,6 +13057,11 @@ pako@^0.2.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
   integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
 
+pako@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
+  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
+
 parallel-transform@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.2.0.tgz#9049ca37d6cb2182c3b1d2c720be94d14a5814fc"
@@ -13107,24 +13263,10 @@ pg-connection-string@^2.4.0, pg-connection-string@^2.5.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
 
-pg-format@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/pg-format/-/pg-format-1.0.4.tgz#27734236c2ad3f4e5064915a59334e20040a828e"
-  integrity sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=
-
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
-
-pg-listen@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/pg-listen/-/pg-listen-1.7.0.tgz#5a5c68a1cabf88d2b78ed9cf133667f597d3b860"
-  integrity sha512-MKDwKLm4ryhy7iq1yw1K1MvUzBdTkaT16HZToddX9QaT8XSdt3Kins5mYH6DLECGFzFWG09VdXvWOIYogjXrsg==
-  dependencies:
-    debug "^4.1.1"
-    pg-format "^1.0.4"
-    typed-emitter "^0.1.0"
 
 pg-pool@^3.4.1:
   version "3.4.1"
@@ -13410,10 +13552,10 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.0.5, prettier@^2.1.2:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^24.9.0:
   version "24.9.0"
@@ -14028,7 +14170,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -14496,14 +14638,6 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-ripemd160@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -14545,12 +14679,12 @@ rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.1, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.3.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+rxjs@^7.5.5:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
-    tslib "~2.1.0"
+    tslib "^2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -14618,11 +14752,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scryptsy@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
-  integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
 
 seamless-immutable@^7.0.1:
   version "7.1.4"
@@ -14731,7 +14860,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sha.js@^2.4.0, sha.js@^2.4.11:
+sha.js@^2.4.11:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
@@ -15946,7 +16075,7 @@ ts-mockito@^2.6.1:
   dependencies:
     lodash "^4.17.5"
 
-ts-node-dev@^1.0.0-pre.40, ts-node-dev@^1.0.0-pre.60, ts-node-dev@^1.0.0-pre.63:
+ts-node-dev@^1.0.0-pre.40, ts-node-dev@^1.0.0-pre.63:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.1.8.tgz#95520d8ab9d45fffa854d6668e2f8f9286241066"
   integrity sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==
@@ -15993,17 +16122,6 @@ ts-node@^7.0.1:
     mkdirp "^0.5.1"
     source-map-support "^0.5.6"
     yn "^2.0.0"
-
-ts-node@^8.10:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
-    yn "3.1.1"
 
 ts-node@^9, ts-node@^9.0.0:
   version "9.1.1"
@@ -16071,11 +16189,6 @@ tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
-tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.21.0"
@@ -16199,11 +16312,6 @@ type@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d"
   integrity sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==
-
-typed-emitter@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-0.1.0.tgz#ca532f100ccbf850e3a73b8ebf43d43e4f1f3849"
-  integrity sha512-Tfay0l6gJMP5rkil8CzGbLthukn+9BN/VXWcABVFPjOoelJ+koW8BuPZYk+h/L+lEeIp1fSzVRiWRPIjKVjPdg==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -16650,7 +16758,7 @@ webpack-bundle-analyzer@^3.3.2:
     opener "^1.5.1"
     ws "^6.0.0"
 
-websocket@^1.0.34:
+websocket@^1.0.32, websocket@^1.0.34:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
   integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
@@ -17073,13 +17181,6 @@ xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
-
-xxhashjs@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
-  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
-  dependencies:
-    cuint "^0.2.2"
 
 y18n@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
**affects:** @joystream/bn-typeorm, @joystream/hydra-cli, @joystream/hydra-common,
@joystream/hydra-db-utils, @joystream/hydra-e2e-tests, @joystream/hydra-indexer-gateway,
@joystream/hydra-indexer, @joystream/hydra-processor, @joystream/hydra-typegen, sample,
sample-mappings

- Updated @polkadot/* dependencies (5.9.1 => 8.9.1)
- Updated bn.js (^5.2.1) and @types/bn.js
(^5.1.0)
- Updated prettier (^2.7.1)
- Added `'@polkadot/api-augment/substrate'` in `SubstrateService.ts`
- Updated `hydra-typegen` to support v14 metadata parsing (type definitions in
metadata), dropped support for `customTypes` and older metadata

**BREAKING CHANGE:**
customTypes and metadata < v14 are no longer supported, @polkadot/api was updated from 5.9.1 =>
8.9.1

**ISSUES CLOSED:** #495