### PR TITLE
Fix: `createdAt` & `updatedAt` fields timestamps inconsistency

### DIFF
--- a/packages/hydra-indexer/src/entities/AbstractWarthogModel.ts
+++ b/packages/hydra-indexer/src/entities/AbstractWarthogModel.ts
@@ -1,9 +1,4 @@
-import {
-  Column,
-  CreateDateColumn,
-  UpdateDateColumn,
-  VersionColumn,
-} from 'typeorm'
+import { Column, VersionColumn } from 'typeorm'
 
 /**
  * Abstract class with Warthog fields. All Entities exposed as warthog model class
@@ -11,7 +6,7 @@ import {
  */
 export abstract class AbstractWarthogModel {
   // Warthog Fields
-  @CreateDateColumn()
+  @Column()
   createdAt!: Date
 
   @Column({
@@ -19,7 +14,7 @@ export abstract class AbstractWarthogModel {
   })
   createdById!: string
 
-  @UpdateDateColumn({ nullable: true })
+  @Column({ nullable: true })
   updatedAt?: Date
 
   @Column({

--- a/packages/hydra-processor/src/executor/TransactionalExecutor.ts
+++ b/packages/hydra-processor/src/executor/TransactionalExecutor.ts
@@ -175,7 +175,7 @@ async function fillRequiredWarthogFields<T extends Record<string, unknown>>(
 
   // set createdAt to the block timestamp if not set
   // eslint-disable-next-line no-prototype-builtins
-  if (entity.hasOwnProperty('createdAt') || entity.createdAt === undefined) {
+  if (!entity.hasOwnProperty('createdAt') || entity.createdAt === undefined) {
     Object.assign(entity, {
       createdAt: new Date(block.timestamp),
     })


### PR DESCRIPTION

Relevant commits 

- [changed AbstractWarthogModel's createdAt & updatedAt field types](https://github.com/Joystream/hydra/commit/7db81dad49a748943d143bdbdf4e0528051e2f7f)
- [fix: don't update createAt field everytime entity is saved](https://github.com/Joystream/hydra/commit/da38fdbea5ff42a19f9731996cacbe9afdcbfd9a)