### PR TITLE
feat: deterministic id generator - utilities exposure fix

### DIFF
--- a/packages/hydra-processor/src/executor/index.ts
+++ b/packages/hydra-processor/src/executor/index.ts
@@ -10,6 +10,7 @@ let mappingsLookup: MappingsLookupService
 export * from './IMappingExecutor'
 export * from './IMappingsLookup'
 export * from './tx-aware'
+export { generateNextId } from './EntityIdGenerator' // expose for external usage
 
 export async function getMappingExecutor(): Promise<IMappingExecutor> {
   if (!mappingExecutor) {


### PR DESCRIPTION
Changes argument of `generateNextId` to be usable in the mappings (outside of Hydra). Related to https://github.com/Joystream/hydra/pull/498.

affects: @joystream/hydra-processor