### PR TITLE
added orderby for each query

### DIFF
--- a/packages/hydra-cli/src/templates/interfaces/service.ts.mst
+++ b/packages/hydra-cli/src/templates/interfaces/service.ts.mst
@@ -71,7 +71,7 @@ export class {{className}}Service {
         (this.typeToService[t]
           .buildFindQueryWithParams(
             <any>where,
-            undefined,
+            ob,
             undefined,
             commonFields,
             (field) => snakeCase(field)


### PR DESCRIPTION
This issue happened in SQL query with "union".
The subqueries didn't contain orderby tags inside it, so it happened.
https://discord.com/channels/811216481340751934/812344874099277824/1026519654006542427
https://github.com/Joystream/pioneer/issues/3125

so i added orderby to each SQL query