### PR TITLE
stateSubscription: Send updates independently from 'processed_events_log_update' table

### DIFF
--- a/packages/hydra-cli/src/codegen/WarthogWrapper.ts
+++ b/packages/hydra-cli/src/codegen/WarthogWrapper.ts
@@ -165,6 +165,7 @@ export default class WarthogWrapper {
       'src/WarthogBaseService.ts',
       'src/processor.resolver.ts',
       'src/queryTemplates.ts',
+      'src/processorStateApp.ts',
       'tsconfig.json',
     ]
 

--- a/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/index.ts.mst
@@ -7,16 +7,18 @@ import { loadConfig } from '../src/config';
 import { Logger } from '../src/logger';
 
 import { buildServerSchema, getServer } from './server';
-import { startPgSubsribers } from './pubsub';
-import { queryTemplates } from './queryTemplates'
-
+import { queryTemplates } from './queryTemplates';
+import { createProcessorStateApp } from './processorStateApp';
+import dns from 'node:dns';
+import { promisify } from 'node:util';
 
 class CustomNamingStrategy extends SnakeNamingStrategy {
   constructor() {
     super();
   }
+
   tableName(className: string, customName?: string): string {
-    return customName ? customName : `${snakeCase(className)}`;
+    return customName || `${snakeCase(className)}`;
   }
 }
 
@@ -31,12 +33,12 @@ async function bootstrap() {
         endpoint: process.env.GRAPHQL_PLAYGROUND_ENDPOINT || undefined,
         subscriptionEndpoint: process.env.GRAPHQL_PLAYGROUND_SUBSCRIPTION_ENDPOINT || undefined,
         queryTemplates,
-      }
+      },
     },
     {
       namingStrategy: new CustomNamingStrategy(),
       maxQueryExecutionTime: 1000,
-      logging: [ process.env.WARTHOG_DB_LOGGING || "error"]
+      logging: [process.env.WARTHOG_DB_LOGGING || 'error'],
     }
   );
 
@@ -48,8 +50,21 @@ async function bootstrap() {
     process.exit(0);
   }
   await buildServerSchema(server);
-  await startPgSubsribers();
   await server.start();
+
+  const lookup = promisify(dns.lookup);
+  let processorAddr: string;
+  try {
+    const { address } = await lookup(process.env.PROCESSOR_HOST || 'localhost');
+    processorAddr = address;
+  } catch (e) {
+    processorAddr = '127.0.0.1';
+  }
+  const processorStateApp = createProcessorStateApp(processorAddr);
+  await processorStateApp.listen(
+    parseInt(process.env.PROCESSOR_STATE_APP_PORT || '8082'),
+    '0.0.0.0'
+  );
 }
 
 bootstrap().catch((error: Error) => {

--- a/packages/hydra-cli/src/templates/graphql-server/src/processor.resolver.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/processor.resolver.ts.mst
@@ -18,7 +18,7 @@ export class ProcessorState {
 
 @Resolver()
 export class ProcessorStateResolver {
-  @Subscription({ topics: TOPICS.processorState })
+  @Subscription({ topics: TOPICS.ProcessorState })
   stateSubscription(
     @Root()
     state: {

--- a/packages/hydra-cli/src/templates/graphql-server/src/processorStateApp.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/processorStateApp.ts.mst
@@ -1,0 +1,79 @@
+import express from 'express';
+import { getPubSub, TOPICS } from './pubsub';
+import { Logger } from './logger';
+
+type ProcessorState = {
+  lastProcessedEvent: string;
+  lastScannedBlock: number;
+  chainHead: number;
+  indexerHead: number;
+};
+
+type Unvalidated<O> =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | unknown[]
+  | { [K in keyof O]?: unknown };
+
+const validateUpdateProcessorStateRequest = (req: express.Request): ProcessorState => {
+  const state: Unvalidated<ProcessorState> = req.body.state;
+  if (
+    state &&
+    typeof state === 'object' &&
+    state !== null &&
+    'lastProcessedEvent' in state &&
+    typeof state.lastProcessedEvent === 'string' &&
+    'lastScannedBlock' in state &&
+    typeof state.lastScannedBlock === 'number' &&
+    Number.isInteger(state.lastScannedBlock) &&
+    state.lastScannedBlock >= 0 &&
+    'chainHead' in state &&
+    typeof state.chainHead === 'number' &&
+    Number.isInteger(state.chainHead) &&
+    state.chainHead >= 0 &&
+    'indexerHead' in state &&
+    typeof state.indexerHead === 'number' &&
+    Number.isInteger(state.indexerHead) &&
+    state.indexerHead >= 0
+  ) {
+    const validated: ProcessorState = {
+      lastProcessedEvent: state.lastProcessedEvent,
+      lastScannedBlock: state.lastScannedBlock,
+      chainHead: state.chainHead,
+      indexerHead: state.indexerHead,
+    };
+    return validated;
+  } else {
+    throw new Error('Request validation failed');
+  }
+};
+
+export function createProcessorStateApp(processorAddr: string): express.Application {
+  const app = express();
+  const pubSub = getPubSub();
+  app.use(express.json());
+  app.post('/update-processor-state', (req, res) => {
+    if (req.ip !== processorAddr) {
+      Logger.warn(`Unauthorized access on /update-processor-state: ${req.ip}`);
+      res.status(403).send('Forbidden');
+      return;
+    }
+    let processorState: ProcessorState;
+    try {
+      processorState = validateUpdateProcessorStateRequest(req);
+    } catch (e) {
+      res.status(400).send((e as Error).message);
+      return;
+    }
+
+    pubSub
+      .publish(TOPICS.ProcessorState, processorState)
+      .then(() => res.status(200).send('OK'))
+      .catch((e) => res.status(500).send(e.message));
+  });
+
+  return app;
+}

--- a/packages/hydra-cli/src/templates/graphql-server/src/pubsub.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/pubsub.ts.mst
@@ -1,52 +1,11 @@
-import { PubSubEngine, PubSub } from 'graphql-subscriptions'
+import { PubSubEngine, PubSub } from 'graphql-subscriptions';
 
-import createSubscriber from 'pg-listen'
-import { Logger } from './logger'
-
-const pubSub: PubSubEngine = new PubSub()
-
-export enum TOPICS {
-  processorState = 'PROCESSOR_STATE',
-}
+const pubSub: PubSubEngine = new PubSub();
 
 export function getPubSub(): PubSubEngine {
-  return pubSub
+  return pubSub;
 }
 
-export async function startPgSubsribers() {
-  // use PG_** env variables to connect
-  const subscriber = createSubscriber()
-  const channel = 'processed_events_log_update'
-
-  subscriber.notifications.on(channel, (payload: unknown) => {
-    const { data } = payload as {
-      data: {
-        event_id: string
-        last_scanned_block: number
-        indexer_head: number
-        chain_head: number
-      }
-    }
-
-    // Payload as passed to subscriber.notify() (see below)
-    pubSub.publish(TOPICS.processorState, {
-      lastProcessedEvent: data.event_id,
-      lastScannedBlock: data.last_scanned_block,
-      chainHead: data.chain_head,
-      indexerHead: data.indexer_head,
-    })
-  })
-
-  subscriber.events.on('error', (error) => {
-    Logger.error('Fatal database connection error:', error)
-    process.exit(1)
-  })
-
-  process.on('exit', () => {
-    Logger.log(`Closing the subscriber`)
-    subscriber.close()
-  })
-
-  await subscriber.connect()
-  await subscriber.listenTo(channel)
+export enum TOPICS {
+  ProcessorState = 'PROCESSOR_STATE',
 }

--- a/packages/hydra-e2e-tests/docker-compose.yml
+++ b/packages/hydra-e2e-tests/docker-compose.yml
@@ -12,8 +12,11 @@ services:
       - DB_PORT=5432
       - GRAPHQL_SERVER_HOST=localhost
       - GRAPHQL_SERVER_PORT=4000
+      - PROCESSOR_STATE_APP_PORT=8082
+      - PROCESSOR_HOST=hydra-processor
     ports:
       - "4000:4000"
+      - "127.0.0.1:8082:8082"
     depends_on:
       - hydra-processor
     command: ["yarn", "query-node:start:prod"]
@@ -38,6 +41,7 @@ services:
       - NODE_URL=ws://node-template:9944
       - POLL_INTERVAL_MS=500 # refresh every second 
       - DEBUG=hydra-processor:*
+      - STATE_UPDATE_ENDPOINT=http://query-node:8082/update-processor-state
     ports:
       - "3000:3000"
     depends_on:

--- a/packages/hydra-processor/package.json
+++ b/packages/hydra-processor/package.json
@@ -60,7 +60,8 @@
     "semver": "^7.3.4",
     "typedi": "^0.8.0",
     "yaml": "^1.10.0",
-    "yaml-validator": "^3.0.0"
+    "yaml-validator": "^3.0.0",
+    "axios": "^1.1.3"
   },
   "devDependencies": {
     "@joystream/hydra-cli": "^4.0.0-alpha.6",

--- a/packages/hydra-processor/src/start/config.ts
+++ b/packages/hydra-processor/src/start/config.ts
@@ -44,6 +44,8 @@ let conf: {
   EVENT_QUEUE_MAX_CAPACITY: number
 
   BLOCK_CACHE_CAPACITY: number
+
+  STATE_UPDATE_ENDPOINT: string
 }
 
 export function configure(): void {
@@ -64,6 +66,9 @@ export function configure(): void {
     QUEUE_FACTOR: num({ default: 2 }),
     QUEUE_MAX_CAP_FACTOR: num({ default: 5 }),
     BLOCK_CACHE_CAPACITY: num({ default: 10000 }),
+    STATE_UPDATE_ENDPOINT: str({
+      devDefault: 'http://localhost:8082/update-processor-state',
+    }),
   })
   conf = {
     ...envConf,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4516,6 +4516,15 @@ axios@^0.21.0, axios@^0.21.4:
   dependencies:
     follow-redirects "^1.14.0"
 
+axios@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.1.3.tgz#8274250dada2edf53814ed7db644b9c2866c1e35"
+  integrity sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
@@ -7900,6 +7909,11 @@ follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -7942,6 +7956,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -13659,7 +13682,7 @@ proxy-agent@~5.0.0:
     proxy-from-env "^1.0.0"
     socks-proxy-agent "^5.0.0"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==


### PR DESCRIPTION
Send updates to `stateSubscription` independently from `processed_events_log_update` table updates.
This is achieved by introducing a new api endpoint `/update-processor-state` in the graphql server, to which (only) the processor can send updates that are then sent from the graphql server to all subscribers.
Processor will send updates to this endpoint (`STATE_UPDATE_ENDPOINT`) on each `ProcessorEvents.PROCESSED_EVENT` and `ProcessorEvents.STATE_CHANGE`.

Can be tested here: https://github.com/Joystream/joystream/pull/4413