### PR TITLE
fix: remove 'Codec' import from template files in generated/types dir

### DIFF
--- a/packages/hydra-typegen/src/templates/module.hbs
+++ b/packages/hydra-typegen/src/templates/module.hbs
@@ -1,6 +1,5 @@
 import { createTypeUnsafe } from "@polkadot/types/create";
 import { SubstrateEvent, SubstrateExtrinsic } from "@joystream/hydra-common";
-import { Codec } from "@polkadot/types/types";
 import { typeRegistry } from ".";
 
 {{{imports}}}


### PR DESCRIPTION
## Problem

In [module.hbs](https://github.com/Joystream/hydra/blob/e2156b800b242f215e9196e123dc511c88019e01/packages/hydra-typegen/src/templates/module.hbs#L3) file in `hydra-typegen` package, there is an unused Codex import as: `import { Codec } from "@polkadot/types/types";`. This template file is being used to generate Events classes for each module inside `query-node/mappings/generated/types/`. The problem is if any event contains a param which is of codex type, then `Codec` is imported again, which leads to duplicate imports error while building the QN.

For example, in https://github.com/Joystream/joystream/pull/4517 the type of optional payment parameter in the MemberRemarked event is `Option<[AccountId32, u128] & Codec>`

## Solution

Remove unused `Codec` import from the template file.


affects: @joystream/hydra-typegen