### PR TITLE
fix: update CI checks runner to latest ubuntu due to failing jobs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   bump:
     name: Bump version
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
           npm whoami
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - name: Install  
+      - name: Install
         run: |
           yarn install --frozen-lockfile
           git config --global user.name 'github-actions'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   publish:
     name: docker-publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   publish:
     name: Publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
see -> https://github.com/Joystream/hydra/actions/runs/4600283498


logs from the failed Github Action: 
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/37098720/229603850-f036524b-87ca-4da4-84bd-22099021eca9.png">
