### PR TITLE
Processor syncing fix (`blocksWithEvents`)

### DIFF
--- a/packages/hydra-cli/src/templates/graphql-server/src/processorStateApp.ts.mst
+++ b/packages/hydra-cli/src/templates/graphql-server/src/processorStateApp.ts.mst
@@ -31,7 +31,7 @@ const validateUpdateProcessorStateRequest = (req: express.Request): ProcessorSta
     'lastScannedBlock' in state &&
     typeof state.lastScannedBlock === 'number' &&
     Number.isInteger(state.lastScannedBlock) &&
-    state.lastScannedBlock >= 0 &&
+    state.lastScannedBlock >= -1 &&
     'chainHead' in state &&
     typeof state.chainHead === 'number' &&
     Number.isInteger(state.chainHead) &&

--- a/packages/hydra-processor/src/queue/BlockQueue.ts
+++ b/packages/hydra-processor/src/queue/BlockQueue.ts
@@ -159,7 +159,13 @@ export class BlockQueue implements IBlockQueue {
 
       debug(`Next block: ${block.id}`)
       // wait until all the events up to blockNumber are fully fetched
-      pWaitFor(() => this.rangeFilter.block.gt >= block.height)
+      await pWaitFor(
+        () =>
+          this.rangeFilter.block.gt >= block.height ||
+          (this.eventQueue.length > 0 &&
+            this.eventQueue[this.eventQueue.length - 1].event.blockNumber >
+              block.height)
+      )
 
       while (
         !this.isEmpty() &&


### PR DESCRIPTION
Fixes https://github.com/Joystream/hydra/issues/519

`blocksWithEvents` `AsyncGenerator` was not properly awaiting the promise returned by `pWaitFor`. This promise was supposed to stop the generator from yeilding next block until all evens emitted in that block were fetched from the indexer.

Becasue it was not properly awaited, it was possible for the `blocksWithEvents` to yeild a block with an incomplete array of events in case the indexer was responsing to requests more slowly than usual.

As a result, the processor would think it processed a full block and update the `last_scanned_block` value in the database, while not actually processing all events from that block. This is the scenario that has caused issues such as https://github.com/Joystream/hydra/issues/519