### PR TITLE
Fix Hydra e2e test

### DIFF
--- a/.github/workflows/hydra-e2e-tests.yml
+++ b/.github/workflows/hydra-e2e-tests.yml
@@ -18,7 +18,11 @@ jobs:
       # Ignore the failure of a step and avoid terminating the job.
       #  continue-on-error: true
       - name: run e2e tests
+        # We use `sudo rm -rf /usr/share/dotnet` as a workaround to free up some space,
+        # as suggested in https://github.com/actions/runner-images/issues/2606#issuecomment-772683150
+        # because by default the runner will run out of space.
         run: |
+          sudo rm -rf /usr/share/dotnet
           yarn 
           yarn build
           yarn e2e-test

--- a/packages/hydra-cli/src/codegen/WarthogWrapper.ts
+++ b/packages/hydra-cli/src/codegen/WarthogWrapper.ts
@@ -210,6 +210,9 @@ export default class WarthogWrapper {
       // this should overwrite warthog dep as well
       ...pkgFile.dependencies,
       ...extraDependencies,
+      // fix the issue with the latest version of @types/lodash
+      // which prevents the graphql-server from compiling
+      '@types/lodash': '4.14.182',
     }
 
     // resolutions can be used for fixing temporary package dependency issues

--- a/packages/hydra-cli/src/templates/scaffold/manifest.yml
+++ b/packages/hydra-cli/src/templates/scaffold/manifest.yml
@@ -1,7 +1,7 @@
-version: '3.0'
+version: '5.0'
 description: Test manifest
 repository: https://github.com/
-hydraVersion: "4"
+hydraVersion: "5"
 dataSource:
   kind: substrate 
   chain: node-template
@@ -16,6 +16,7 @@ typegen:
   calls:
     - timestamp.set
   outDir: ./mappings/generated/types
+  typegenBinPath: ./node_modules/.bin/polkadot-types-from-defs
 mappings:
   mappingsModule: mappings/lib/mappings
   imports:

--- a/packages/hydra-e2e-tests/docker-compose.yml
+++ b/packages/hydra-e2e-tests/docker-compose.yml
@@ -97,11 +97,11 @@ services:
     
     
   node-template:
-    image: paritytech/substrate-playground-template-node-template:sha-7212614
+    image: paritytech/substrate-playground-template-node-template:sha-af065c19
     restart: unless-stopped
     ports:
       - "9944:9944"
-    command: ["./target/release/node-template", "--dev", "--tmp", "--ws-external"]
+    command: ["./target/debug/node-template", "--dev", "--tmp", "--ws-external"]
 
   redis:
     image: redis:6.0-alpine

--- a/packages/hydra-e2e-tests/fixtures/manifest.yml
+++ b/packages/hydra-e2e-tests/fixtures/manifest.yml
@@ -1,7 +1,7 @@
-version: '3.0'
+version: '5.0'
 description: Test manifest
 repository: https://github.com/
-hydraVersion: "4"
+hydraVersion: "5"
 dataSource:
   kind: substrate 
   chain: node-template
@@ -15,6 +15,7 @@ typegen:
   calls:
     - timestamp.set
   outDir: ./mappings/generated/types
+  typegenBinPath: ./node_modules/.bin/polkadot-types-from-defs
 mappings:
   mappingsModule: mappings/lib/mappings
   imports:

--- a/packages/hydra-e2e-tests/fixtures/mappings/mappings.ts
+++ b/packages/hydra-e2e-tests/fixtures/mappings/mappings.ts
@@ -9,7 +9,7 @@ import {
 
 // run 'NODE_URL=<RPC_ENDPOINT> EVENTS=<comma separated list of events> yarn codegen:mappings-types'
 // to genenerate typescript classes for events, such as Balances.TransferEvent
-import { Balances, Timestamp } from './generated/types'
+import { Balances_TransferEvent_V100, SetCall } from './generated/types'
 import BN from 'bn.js'
 import {
   ExtrinsicContext,
@@ -43,7 +43,7 @@ export async function balancesTransfer({
   extrinsic,
 }: EventContext & StoreContext) {
   const transfer = new Transfer()
-  const [from, to, value] = new Balances.TransferEvent(event).params
+  const [from, to, value] = new Balances_TransferEvent_V100(event).params
   transfer.from = Buffer.from(from.toHex())
   transfer.to = Buffer.from(to.toHex())
   transfer.value = value.toBn()
@@ -106,7 +106,7 @@ export async function timestampCall({
   event,
   block: { height, hash, timestamp },
 }: ExtrinsicContext & StoreContext) {
-  const call = new Timestamp.SetCall(event)
+  const call = new SetCall(event)
   const ts = call.args.now.toBn()
 
   const blockTs = new BlockTimestamp()

--- a/packages/hydra-processor/test/fixtures/manifest.yml
+++ b/packages/hydra-processor/test/fixtures/manifest.yml
@@ -1,7 +1,7 @@
-version: '0.2'
+version: '5.0'
 description: Test manifest
 repository: https://github.com/
-hydraVersion: '4'
+hydraVersion: '5'
 dataSource:
   kind: substrate
   chain: node-template

--- a/packages/hydra-typegen/package.json
+++ b/packages/hydra-typegen/package.json
@@ -42,6 +42,7 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1.3.3",
     "@polkadot/api": "8.9.1",
+    "@polkadot/typegen": "8.9.1",
     "debug": "^4.3.1",
     "figlet": "^1.5.2",
     "handlebars": "^4.7.6",

--- a/packages/sample/manifest.yml
+++ b/packages/sample/manifest.yml
@@ -1,8 +1,8 @@
-version: '3.0'
+version: '5.0'
 description: Sample manifest
 repository: https://github.com/
 ## reserved but unused fields
-hydraVersion: '4'
+hydraVersion: '5'
 dataSource:
   kind: substrate 
   chain: node-template


### PR DESCRIPTION
Fix Hydra e2e test by updating Hydra-CLI scaffold (`@types/lodash` issue discovered in: https://github.com/Joystream/hydra/pull/518#pullrequestreview-1367100147) and the test fixtures

affects: @joystream/hydra-cli, @joystream/hydra-e2e-tests, @joystream/hydra-typegen